### PR TITLE
feat: add manual entries and statistics improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 /.idea/workspace.xml
 /.idea/navEditor.xml
 /.idea/assetWizardSettings.xml
+/.idea/claudeCodeTabState.xml
+/.kotlin/
 .DS_Store
 /build
 /captures

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -50,3 +50,20 @@
 -keep class me.neko.nzhelper.ui.util.GitHubRelease {
     *;
 }
+
+# === 保留数据类 CustomOptions ===
+-keep class me.neko.nzhelper.data.CustomOptions {
+    *;
+}
+
+# 保留 Gson 使用的泛型类型信息
+-keepattributes Signature
+-keepattributes *Annotation*
+
+# 保留 Kotlin 元数据（如果使用 Kotlin 反射）
+-keep class kotlin.Metadata { *; }
+
+# 保留所有 data class 的 componentN() 方法
+-keepclassmembers class ** {
+    public *** componentN();
+}

--- a/app/src/main/java/me/neko/nzhelper/data/SessionRepository.kt
+++ b/app/src/main/java/me/neko/nzhelper/data/SessionRepository.kt
@@ -10,24 +10,32 @@ import java.time.LocalDateTime
 
 // 公共数据类
 data class Session(
-    val timestamp: LocalDateTime,
-    val duration: Int,
-    val remark: String,
-    val location: String,
-    val watchedMovie: Boolean,
-    val climax: Boolean,
-    val rating: Float,
-    val mood: String,
-    val props: String
+    val timestamp: LocalDateTime?,  // 允许为 null，兼容旧数据
+    val duration: Int = 0,
+    val remark: String = "",
+    val location: String = "",
+    val watchedMovie: Boolean = false,
+    val climax: Boolean = false,
+    val rating: Float = 3f,
+    val mood: String = "平静",
+    val props: String = "手"
+)
+
+// 自定义选项配置
+data class CustomOptions(
+    val moods: List<String> = listOf("平静", "愉悦", "兴奋", "疲惫", "这是最后一次！"),
+    val props: List<String> = listOf("手", "斐济杯", "小胶妻")
 )
 
 object SessionRepository {
 
     private const val PREFS_NAME = "sessions_prefs"
     private const val KEY_SESSIONS = "sessions"
+    private const val KEY_CUSTOM_OPTIONS = "custom_options"
 
     private val gson = NzApplication.gson
     private val sessionsTypeToken = object : TypeToken<List<Session>>() {}.type
+    private val customOptionsTypeToken = object : TypeToken<CustomOptions>() {}.type
 
     suspend fun loadSessions(context: Context): List<Session> = withContext(Dispatchers.IO) {
         val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -36,9 +44,11 @@ object SessionRepository {
             emptyList()
         } else {
             try {
-                gson.fromJson(json, sessionsTypeToken) ?: emptyList()
+                @Suppress("UNCHECKED_CAST")
+                gson.fromJson(json, sessionsTypeToken) as? List<Session> ?: emptyList()
             } catch (e: Exception) {
                 e.printStackTrace()
+                // 如果反序列化失败，返回空列表而不是崩溃
                 emptyList()
             }
         }
@@ -49,5 +59,30 @@ object SessionRepository {
             val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
             val json = gson.toJson(sessions)
             prefs.edit { putString(KEY_SESSIONS, json) }
+        }
+
+    // 加载自定义选项
+    suspend fun loadCustomOptions(context: Context): CustomOptions = withContext(Dispatchers.IO) {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val json = prefs.getString(KEY_CUSTOM_OPTIONS, null)
+        if (json.isNullOrEmpty()) {
+            CustomOptions() // 返回默认值
+        } else {
+            try {
+                @Suppress("UNCHECKED_CAST")
+                gson.fromJson(json, customOptionsTypeToken) as? CustomOptions ?: CustomOptions()
+            } catch (e: Exception) {
+                e.printStackTrace()
+                CustomOptions() // 如果解析失败，返回默认值
+            }
+        }
+    }
+
+    // 保存自定义选项
+    suspend fun saveCustomOptions(context: Context, options: CustomOptions) =
+        withContext(Dispatchers.IO) {
+            val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            val json = gson.toJson(options)
+            prefs.edit { putString(KEY_CUSTOM_OPTIONS, json) }
         }
 }

--- a/app/src/main/java/me/neko/nzhelper/ui/dialog/CustomOptionsDialog.kt
+++ b/app/src/main/java/me/neko/nzhelper/ui/dialog/CustomOptionsDialog.kt
@@ -1,0 +1,177 @@
+package me.neko.nzhelper.ui.dialog
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun CustomOptionsDialog(
+    show: Boolean,
+    title: String,
+    initialOptions: List<String>,
+    onConfirm: (List<String>) -> Unit,
+    onDismiss: () -> Unit
+) {
+    if (!show) return
+
+    val options = remember { mutableStateListOf<String>().apply { addAll(initialOptions) } }
+    var newOptionText by remember { mutableStateOf("") }
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Surface(
+            shape = MaterialTheme.shapes.extraLarge,
+            tonalElevation = 8.dp,
+            modifier = Modifier
+                .fillMaxWidth(0.9f)
+                .wrapContentHeight()
+        ) {
+            Column(
+                modifier = Modifier
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 16.dp, vertical = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Text(
+                    text = "自定义$title",
+                    style = MaterialTheme.typography.titleLarge,
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                // 添加新选项
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    OutlinedTextField(
+                        value = newOptionText,
+                        onValueChange = { newOptionText = it },
+                        placeholder = { Text("输入新的$title") },
+                        modifier = Modifier.weight(1f),
+                        singleLine = true
+                    )
+                    
+                    IconButton(
+                        onClick = {
+                            if (newOptionText.isNotBlank() && newOptionText !in options) {
+                                options.add(newOptionText.trim())
+                                newOptionText = ""
+                            }
+                        },
+                        enabled = newOptionText.isNotBlank() && newOptionText !in options
+                    ) {
+                        Icon(Icons.Default.Add, contentDescription = "添加")
+                    }
+                }
+
+                // 已有选项列表
+                FlowRow(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    options.forEachIndexed { index, option ->
+                        FilterChip(
+                            selected = false,
+                            onClick = { },
+                            label = { Text(option) },
+                            trailingIcon = {
+                                IconButton(
+                                    onClick = { options.removeAt(index) },
+                                    modifier = Modifier.size(18.dp)
+                                ) {
+                                    Icon(
+                                        Icons.Default.Close,
+                                        contentDescription = "删除",
+                                        modifier = Modifier.size(14.dp)
+                                    )
+                                }
+                            },
+                            modifier = Modifier
+                        )
+                    }
+                }
+
+                // 提示文字
+                Text(
+                    text = "点击右侧的 × 删除选项，至少保留一个选项",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 4.dp)
+                )
+
+                // 底部按钮
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Button(
+                        onClick = onDismiss,
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(44.dp),
+                        shape = RoundedCornerShape(16.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                            contentColor = MaterialTheme.colorScheme.secondary
+                        )
+                    ) {
+                        Text("取消")
+                    }
+
+                    Button(
+                        onClick = { onConfirm(options.toList()) },
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(44.dp),
+                        shape = RoundedCornerShape(16.dp),
+                        enabled = options.isNotEmpty()
+                    ) {
+                        Text("保存")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/me/neko/nzhelper/ui/dialog/DetailsDialog.kt
+++ b/app/src/main/java/me/neko/nzhelper/ui/dialog/DetailsDialog.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -17,6 +16,7 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Done
 import androidx.compose.material3.Button
@@ -59,6 +59,8 @@ fun DetailsDialog(
     onRatingChange: (Float) -> Unit,
     mood: String,
     onMoodChange: (String) -> Unit,
+    customMoods: List<String> = listOf("平静", "愉悦", "兴奋", "疲惫", "这是最后一次！"),
+    customProps: List<String> = listOf("手", "斐济杯", "小胶妻"),
     onConfirm: () -> Unit,
     onDismiss: () -> Unit
 ) {
@@ -111,7 +113,7 @@ fun DetailsDialog(
 
                 SelectionSection(
                     title = "道具",
-                    items = listOf("手", "斐济杯", "小胶妻"),
+                    items = customProps,
                     selected = props,
                     onSelected = onPropsChange
                 )
@@ -120,7 +122,7 @@ fun DetailsDialog(
 
                 SelectionSection(
                     title = "心情",
-                    items = listOf("平静", "愉悦", "兴奋", "疲惫", "这是最后一次！"),
+                    items = customMoods,
                     selected = mood,
                     onSelected = onMoodChange
                 )
@@ -235,9 +237,12 @@ private fun SelectionSection(
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         Text(title, style = MaterialTheme.typography.titleMedium)
 
-        FlowRow(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(10.dp)
+        // 使用横向滚动布局，避免多行堆叠
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState()),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             items.forEach { item ->
                 FilterChip(

--- a/app/src/main/java/me/neko/nzhelper/ui/dialog/ManualAddDialog.kt
+++ b/app/src/main/java/me/neko/nzhelper/ui/dialog/ManualAddDialog.kt
@@ -1,0 +1,506 @@
+package me.neko.nzhelper.ui.dialog
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Done
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.DisplayMode
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TimePicker
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.material3.rememberTimePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import kotlin.math.roundToInt
+
+// 扩展函数：复制 LocalDateTime 的日期部分
+private fun LocalDateTime.withDate(newDate: LocalDate): LocalDateTime {
+    return this.withYear(newDate.year)
+        .withMonth(newDate.monthValue)
+        .withDayOfMonth(newDate.dayOfMonth)
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun ManualAddDialog(
+    show: Boolean,
+    selectedDateTime: LocalDateTime,
+    onSelectedDateTimeChange: (LocalDateTime) -> Unit,
+    durationSeconds: Int,
+    onDurationSecondsChange: (Int) -> Unit,
+    remark: String,
+    onRemarkChange: (String) -> Unit,
+    location: String,
+    onLocationChange: (String) -> Unit,
+    watchedMovie: Boolean,
+    onWatchedMovieChange: (Boolean) -> Unit,
+    climax: Boolean,
+    onClimaxChange: (Boolean) -> Unit,
+    props: String,
+    onPropsChange: (String) -> Unit,
+    rating: Float,
+    onRatingChange: (Float) -> Unit,
+    mood: String,
+    onMoodChange: (String) -> Unit,
+    customMoods: List<String> = listOf("平静", "愉悦", "兴奋", "疲惫", "这是最后一次！"),
+    customProps: List<String> = listOf("手", "斐济杯", "小胶妻"),
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    if (!show) return
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Surface(
+            shape = MaterialTheme.shapes.extraLarge,
+            tonalElevation = 8.dp,
+            modifier = Modifier
+                .fillMaxWidth(0.92f)
+                .wrapContentHeight()
+        ) {
+            Column(
+                modifier = Modifier
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 10.dp, vertical = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(6.dp)
+            ) {
+                Text(
+                    text = "手动添加记录",
+                    style = MaterialTheme.typography.titleLarge,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                // 日期时间选择
+                InputSection(title = "发生时间") {
+                    var showDatePicker by remember { mutableStateOf(false) }
+                    var showTimePicker by remember { mutableStateOf(false) }
+                    
+                    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                        // 显示当前选中的日期时间
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clip(MaterialTheme.shapes.medium)
+                                .border(
+                                    width = 1.dp,
+                                    color = MaterialTheme.colorScheme.outline,
+                                    shape = MaterialTheme.shapes.medium
+                                )
+                                .clickable { showDatePicker = true }
+                                .padding(horizontal = 10.dp, vertical = 6.dp)
+                        ) {
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = "日期",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                                Text(
+                                    text = selectedDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")),
+                                    style = MaterialTheme.typography.bodyLarge
+                                )
+                            }
+                            Column(
+                                modifier = Modifier.weight(1f),
+                                horizontalAlignment = Alignment.End
+                            ) {
+                                Text(
+                                    text = "时间",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                                Text(
+                                    text = selectedDateTime.format(DateTimeFormatter.ofPattern("HH:mm")),
+                                    style = MaterialTheme.typography.bodyLarge
+                                )
+                            }
+                        }
+                    }
+                    
+                    // 日期选择器弹窗
+                    if (showDatePicker) {
+                        val datePickerState = rememberDatePickerState(
+                            initialSelectedDateMillis = selectedDateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+                        )
+                        DatePickerDialog(
+                            onDismissRequest = { showDatePicker = false },
+                            confirmButton = {
+                                Button(
+                                    onClick = {
+                                        datePickerState.selectedDateMillis?.let { millis ->
+                                            val newDate = Instant.ofEpochMilli(millis)
+                                                .atZone(ZoneId.systemDefault())
+                                                .toLocalDate()
+                                            // 检查是否选择了未来的日期
+                                            val now = LocalDateTime.now()
+                                            val selectedDateTimeWithNewDate = newDate.atTime(now.hour, now.minute)
+                                            if (selectedDateTimeWithNewDate.isAfter(now)) {
+                                                // 如果选择了未来日期，重置到今天
+                                                onSelectedDateTimeChange(now)
+                                            } else {
+                                                val newDateTime = selectedDateTime.withDate(newDate)
+                                                onSelectedDateTimeChange(newDateTime)
+                                            }
+                                        }
+                                        showDatePicker = false
+                                        // 显示时间选择器
+                                        showTimePicker = true
+                                    }
+                                ) {
+                                    Text("确定")
+                                }
+                            },
+                            dismissButton = {
+                                Button(
+                                    onClick = { showDatePicker = false }
+                                ) {
+                                    Text("取消")
+                                }
+                            }
+                        ) {
+                            DatePicker(state = datePickerState)
+                        }
+                    }
+                    
+                    // 时间选择器弹窗
+                    if (showTimePicker) {
+                        val timePickerState = rememberTimePickerState(
+                            initialHour = selectedDateTime.hour,
+                            initialMinute = selectedDateTime.minute,
+                            is24Hour = true
+                        )
+                        DatePickerDialog(
+                            onDismissRequest = { showTimePicker = false },
+                            confirmButton = {
+                                Button(
+                                    onClick = {
+                                        val newDateTime = selectedDateTime
+                                            .withHour(timePickerState.hour)
+                                            .withMinute(timePickerState.minute)
+                                        onSelectedDateTimeChange(newDateTime)
+                                        showTimePicker = false
+                                    }
+                                ) {
+                                    Text("确定")
+                                }
+                            },
+                            dismissButton = {
+                                Button(
+                                    onClick = { showTimePicker = false }
+                                ) {
+                                    Text("取消")
+                                }
+                            }
+                        ) {
+                            Surface(
+                                modifier = Modifier.padding(16.dp),
+                                color = MaterialTheme.colorScheme.surface
+                            ) {
+                                TimePicker(state = timePickerState)
+                            }
+                        }
+                    }
+                }
+
+                // 时长输入
+                InputSection(title = "持续时长") {
+                    val minutes = durationSeconds / 60
+                    
+                    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                        // 显示当前时长
+                        Text(
+                            text = "已设置：${minutes}分钟",
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                        
+                        // 快速选择按钮
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(4.dp)
+                        ) {
+                            listOf(-30, -15, -10, -5, +5, +10, +15, +30).forEach { mins ->
+                                Button(
+                                    onClick = { 
+                                        val newMinutes = (minutes + mins).coerceAtLeast(0)
+                                        onDurationSecondsChange(newMinutes * 60)
+                                    },
+                                    modifier = Modifier.weight(1f),
+                                    contentPadding = PaddingValues(4.dp)
+                                ) {
+                                    Text(
+                                        text = if (mins > 0) "+$mins" else "$mins",
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        maxLines = 1
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+
+                HorizontalDivider(
+                    color = MaterialTheme.colorScheme.outlineVariant,
+                    thickness = 0.5.dp
+                )
+
+                InputSection(title = "起飞地点（可选）") {
+                    OutlinedTextField(
+                        value = location,
+                        onValueChange = onLocationChange,
+                        placeholder = { Text("例如：卧室") },
+                        modifier = Modifier.fillMaxWidth(),
+                        maxLines = 2
+                    )
+                }
+
+                CheckboxGroup(
+                    watchedMovie = watchedMovie,
+                    onWatchedMovieChange = onWatchedMovieChange,
+                    climax = climax,
+                    onClimaxChange = onClimaxChange
+                )
+
+                HorizontalDivider(
+                    color = MaterialTheme.colorScheme.outlineVariant,
+                    thickness = 0.5.dp
+                )
+
+                SelectionSection(
+                    title = "道具",
+                    items = customProps,
+                    selected = props,
+                    onSelected = onPropsChange
+                )
+
+                RatingSection(rating = rating, onRatingChange = onRatingChange)
+
+                SelectionSection(
+                    title = "心情",
+                    items = customMoods,
+                    selected = mood,
+                    onSelected = onMoodChange
+                )
+
+                InputSection(title = "备注（可选）") {
+                    OutlinedTextField(
+                        value = remark,
+                        onValueChange = onRemarkChange,
+                        placeholder = { Text("有什么想说的？") },
+                        modifier = Modifier.fillMaxWidth(),
+                        maxLines = 2
+                    )
+                }
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(6.dp)
+                ) {
+                    Button(
+                        onClick = onDismiss,
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(38.dp),
+                        shape = RoundedCornerShape(14.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                            contentColor = MaterialTheme.colorScheme.secondary
+                        )
+                    ) {
+                        Text("取消", style = MaterialTheme.typography.bodyMedium)
+                    }
+
+                    Button(
+                        onClick = onConfirm,
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(38.dp),
+                        shape = RoundedCornerShape(14.dp)
+                    ) {
+                        Text("确认保存", style = MaterialTheme.typography.bodyMedium)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun InputSection(
+    title: String,
+    content: @Composable () -> Unit
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(title, style = MaterialTheme.typography.titleMedium)
+        content()
+    }
+}
+
+@Composable
+private fun CheckboxGroup(
+    watchedMovie: Boolean,
+    onWatchedMovieChange: (Boolean) -> Unit,
+    climax: Boolean,
+    onClimaxChange: (Boolean) -> Unit
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(MaterialTheme.shapes.medium)
+                .border(
+                    width = 1.dp,
+                    color = MaterialTheme.colorScheme.outline,
+                    shape = MaterialTheme.shapes.medium
+                )
+                .clickable { onWatchedMovieChange(!watchedMovie) }
+                .padding(horizontal = 6.dp, vertical = 8.dp)
+        ) {
+            Checkbox(checked = watchedMovie, onCheckedChange = null)
+            Spacer(Modifier.width(10.dp))
+            Text("配菜", style = MaterialTheme.typography.bodyMedium)
+        }
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(MaterialTheme.shapes.medium)
+                .border(
+                    width = 1.dp,
+                    color = MaterialTheme.colorScheme.outline,
+                    shape = MaterialTheme.shapes.medium
+                )
+                .clickable { onClimaxChange(!climax) }
+                .padding(horizontal = 6.dp, vertical = 8.dp)
+        ) {
+            Checkbox(checked = climax, onCheckedChange = null)
+            Spacer(Modifier.width(10.dp))
+            Text("是否发射", style = MaterialTheme.typography.bodyMedium)
+        }
+    }
+}
+
+@Composable
+private fun SelectionSection(
+    title: String,
+    items: List<String>,
+    selected: String,
+    onSelected: (String) -> Unit
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(title, style = MaterialTheme.typography.titleMedium)
+
+        // 使用横向滚动布局，避免多行堆叠
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState()),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            items.forEach { item ->
+                FilterChip(
+                    onClick = { onSelected(item) },
+                    label = { Text(item) },
+                    selected = selected == item,
+                    leadingIcon = if (selected == item) {
+                        {
+                            Icon(
+                                imageVector = Icons.Default.Done,
+                                contentDescription = null,
+                                modifier = Modifier.size(FilterChipDefaults.IconSize)
+                            )
+                        }
+                    } else null
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun RatingSection(
+    rating: Float,
+    onRatingChange: (Float) -> Unit
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text("评分", style = MaterialTheme.typography.titleMedium)
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(
+                text = "%.1f".format(rating),
+                style = MaterialTheme.typography.headlineMedium,
+                modifier = Modifier.width(48.dp)
+            )
+
+            Slider(
+                value = rating,
+                onValueChange = { newValue ->
+                    val rounded = (newValue * 2).roundToInt() / 2f
+                    onRatingChange(rounded.coerceIn(0f, 5f))
+                },
+                valueRange = 0f..5f,
+                steps = 9,
+                modifier = Modifier.weight(1f)
+            )
+
+            Text(
+                text = "/ 5.0",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.width(48.dp)
+            )
+        }
+    }
+}

--- a/app/src/main/java/me/neko/nzhelper/ui/screens/AboutScreen.kt
+++ b/app/src/main/java/me/neko/nzhelper/ui/screens/AboutScreen.kt
@@ -24,14 +24,13 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.DividerDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.LargeFlexibleTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
@@ -55,7 +54,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import me.neko.nzhelper.R
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AboutScreen(
     navController: NavHostController
@@ -81,7 +80,7 @@ fun AboutScreen(
 
     Scaffold(
         topBar = {
-            LargeFlexibleTopAppBar(
+            TopAppBar(
                 title = { Text("关于") },
                 navigationIcon = {
                     IconButton(onClick = { navController.popBackStack() }) {

--- a/app/src/main/java/me/neko/nzhelper/ui/screens/HistoryScreen.kt
+++ b/app/src/main/java/me/neko/nzhelper/ui/screens/HistoryScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material.icons.rounded.DeleteForever
@@ -39,21 +40,22 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.LargeFlexibleTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -72,10 +74,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import me.neko.nzhelper.NzApplication
+import me.neko.nzhelper.data.CustomOptions
 import me.neko.nzhelper.data.Session
 import me.neko.nzhelper.data.SessionRepository
 import me.neko.nzhelper.ui.dialog.CustomAppAlertDialog
-import me.neko.nzhelper.ui.dialog.DetailsDialog
+import me.neko.nzhelper.ui.dialog.ManualAddDialog
 import java.io.OutputStreamWriter
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -91,7 +94,7 @@ private fun formatTime(totalSeconds: Int): String {
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HistoryScreen() {
     val context = LocalContext.current
@@ -101,8 +104,18 @@ fun HistoryScreen() {
     val sessionsTypeToken = object : TypeToken<List<Session>>() {}.type
 
     var editSession by remember { mutableStateOf<Session?>(null) }
-    var showDetailsDialog by remember { mutableStateOf(false) }
     var isEditing by remember { mutableStateOf(false) }
+    
+    // 加载自定义选项（带默认值）
+    var customOptions by remember { mutableStateOf(me.neko.nzhelper.data.CustomOptions()) }
+    LaunchedEffect(Unit) {
+        customOptions = SessionRepository.loadCustomOptions(context)
+    }
+    
+    // 手动添加记录的状态
+    var showManualAddDialog by remember { mutableStateOf(false) }
+    var manualDateTime by remember { mutableStateOf(LocalDateTime.now()) }
+    var manualDurationSeconds by remember { mutableIntStateOf(0) }
 
     var remarkInput by remember { mutableStateOf("") }
     var locationInput by remember { mutableStateOf("") }
@@ -116,6 +129,68 @@ fun HistoryScreen() {
     var showClearDialog by remember { mutableStateOf(false) }
     var sessionToDelete by remember { mutableStateOf<Session?>(null) }
     var sessionToView by remember { mutableStateOf<Session?>(null) }
+    
+    // 自定义选项导入导出
+    val importOptionsLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocument()
+    ) { uri: Uri? ->
+        uri?.let { importUri ->
+            scope.launch {
+                try {
+                    context.contentResolver.openInputStream(importUri)?.use { inputStream ->
+                        val jsonStr = inputStream.bufferedReader().readText()
+                        val importedOptions = NzApplication.gson.fromJson(
+                            jsonStr,
+                            object : TypeToken<CustomOptions>() {}.type
+                        ) as? CustomOptions
+                        
+                        if (importedOptions != null) {
+                            SessionRepository.saveCustomOptions(context, importedOptions)
+                            customOptions = importedOptions
+                            withContext(Dispatchers.Main) {
+                                Toast.makeText(
+                                    context,
+                                    "成功导入自定义选项",
+                                    Toast.LENGTH_SHORT
+                                ).show()
+                            }
+                        } else {
+                            Toast.makeText(context, "导入失败：文件格式不正确", Toast.LENGTH_SHORT)
+                                .show()
+                        }
+                    }
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                    Toast.makeText(context, "导入失败：${e.message}", Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+    }
+
+    val exportOptionsLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.CreateDocument("application/json")
+    ) { uri: Uri? ->
+        uri?.let { exportUri ->
+            scope.launch {
+                try {
+                    context.contentResolver.openOutputStream(exportUri)?.use { outputStream ->
+                        val json = NzApplication.gson.toJson(customOptions)
+                        outputStream.write(json.toByteArray())
+                        withContext(Dispatchers.Main) {
+                            Toast.makeText(
+                                context,
+                                "成功导出自定义选项",
+                                Toast.LENGTH_SHORT
+                            ).show()
+                        }
+                    }
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                    Toast.makeText(context, "导出失败：${e.message}", Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+    }
 
     val scrollBehavior =
         TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState())
@@ -131,16 +206,22 @@ fun HistoryScreen() {
                         val importedSessions = mutableListOf<Session>()
 
                         var success = false
+                        
+                        // 1. 首先尝试新格式（完整字段名的 JSON 对象）
                         try {
                             val newList: List<Session> =
                                 NzApplication.gson.fromJson(jsonStr, sessionsTypeToken)
-                            importedSessions.addAll(newList)
-                            success = true
-                        } catch (_: Exception) {
+                            // 过滤掉没有 timestamp 的数据
+                            importedSessions.addAll(newList.filter { it.timestamp != null })
+                            if (importedSessions.isNotEmpty()) {
+                                success = true
+                            }
+                        } catch (e: Exception) {
+                            e.printStackTrace()
                             // 新格式失败，继续尝试旧格式
                         }
 
-                        // 如果新格式失败，尝试旧数组格式
+                        // 2. 如果新格式失败，尝试旧数组格式 [[timestamp, duration, ...]]
                         if (!success) {
                             try {
                                 val root = parseString(jsonStr).asJsonArray
@@ -183,16 +264,66 @@ fun HistoryScreen() {
                                         )
                                     }
                                 }
+                                if (importedSessions.isNotEmpty()) {
+                                    success = true
+                                }
                             } catch (parseException: Exception) {
                                 parseException.printStackTrace()
+                            }
+                        }
+                        
+                        // 3. 如果还是失败，尝试解析单字母字段名的 JSON 对象格式 {"a":..., "b":...}
+                        if (!success) {
+                            try {
+                                val jsonArray = parseString(jsonStr).asJsonArray
+                                for (elem in jsonArray) {
+                                    if (elem.isJsonObject) {
+                                        val obj = elem.asJsonObject
+                                        val timeStr = obj.get("a")?.asString
+                                        if (timeStr != null) {
+                                            val timestamp = LocalDateTime.parse(
+                                                timeStr,
+                                                DateTimeFormatter.ISO_LOCAL_DATE_TIME
+                                            )
+                                            val duration = obj.get("b")?.asInt ?: 0
+                                            val remark = obj.get("c")?.asString ?: ""
+                                            val location = obj.get("d")?.asString ?: ""
+                                            val watchedMovie = obj.get("e")?.asBoolean ?: false
+                                            val climax = obj.get("f")?.asBoolean ?: false
+                                            val rating = obj.get("g")?.asFloat?.coerceIn(0f, 5f) ?: 3f
+                                            val mood = obj.get("h")?.asString ?: "平静"
+                                            val props = obj.get("i")?.asString ?: "手"
+
+                                            importedSessions.add(
+                                                Session(
+                                                    timestamp = timestamp,
+                                                    duration = duration,
+                                                    remark = remark,
+                                                    location = location,
+                                                    watchedMovie = watchedMovie,
+                                                    climax = climax,
+                                                    rating = rating,
+                                                    mood = mood,
+                                                    props = props
+                                                )
+                                            )
+                                        }
+                                    }
+                                }
+                                if (importedSessions.isNotEmpty()) {
+                                    success = true
+                                }
+                            } catch (e: Exception) {
+                                e.printStackTrace()
                             }
                         }
 
                         // 统一处理导入结果
                         if (importedSessions.isNotEmpty()) {
+                            val sortedSessions = importedSessions.sortedByDescending { it.timestamp }
                             sessions.clear()
-                            sessions.addAll(importedSessions)
-                            SessionRepository.saveSessions(context, sessions)
+                            sessions.addAll(sortedSessions)
+                            SessionRepository.saveSessions(context, sortedSessions)
 
                             withContext(Dispatchers.Main) {
                                 Toast.makeText(
@@ -231,16 +362,22 @@ fun HistoryScreen() {
         }
     }
 
-    // 加载历史记录
     LaunchedEffect(Unit) {
-        val loaded = SessionRepository.loadSessions(context)
-        sessions.clear()
-        sessions.addAll(loaded)
+        try {
+            val loaded = SessionRepository.loadSessions(context)
+            val validSessions = loaded.filter { it.timestamp != null }
+                .sortedByDescending { it.timestamp }
+            sessions.clear()
+            sessions.addAll(validSessions)
+        } catch (e: Exception) {
+            e.printStackTrace()
+            sessions.clear()
+        }
     }
 
     Scaffold(
         topBar = {
-            LargeFlexibleTopAppBar(
+            TopAppBar(
                 title = { Text("历史记录") },
                 actions = {
                     IconButton(onClick = { showMenu = true }) {
@@ -276,6 +413,30 @@ fun HistoryScreen() {
                 scrollBehavior = scrollBehavior
             )
         },
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = {
+                    // 打开手动添加记录弹窗
+                    manualDateTime = LocalDateTime.now()
+                    manualDurationSeconds = 0
+                    remarkInput = ""
+                    locationInput = ""
+                    watchedMovie = false
+                    climax = false
+                    rating = 3f
+                    mood = "平静"
+                    props = "手"
+                    showManualAddDialog = true
+                },
+                containerColor = MaterialTheme.colorScheme.primary,
+                contentColor = MaterialTheme.colorScheme.onPrimary
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Add,
+                    contentDescription = "手动添加记录"
+                )
+            }
+        },
         contentWindowInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal)
     ) { innerPadding ->
         Box(
@@ -300,7 +461,11 @@ fun HistoryScreen() {
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                     contentPadding = PaddingValues(16.dp)
                 ) {
-                    items(sessions, key = { it.timestamp }) { session ->
+                    items(
+                        items = sessions,
+                        key = { session -> session.timestamp?.toString() ?: session.hashCode() }
+                    ) { session ->
+                        
                         ElevatedCard(
                             modifier = Modifier
                                 .fillMaxWidth()
@@ -316,7 +481,7 @@ fun HistoryScreen() {
                                 ) {
                                     Column {
                                         Text(
-                                            session.timestamp.format(
+                                            session.timestamp!!.format(
                                                 DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
                                             )
                                         )
@@ -352,7 +517,7 @@ fun HistoryScreen() {
                     onConfirm = {
                         sessions.remove(session)
                         scope.launch {
-                            SessionRepository.saveSessions(context, sessions)
+                            SessionRepository.saveSessions(context, sessions.toList())
                         }
                     },
                     onDismiss = { sessionToDelete = null },
@@ -373,7 +538,7 @@ fun HistoryScreen() {
                     onConfirm = {
                         sessions.clear()
                         scope.launch {
-                            SessionRepository.saveSessions(context, sessions)
+                            SessionRepository.saveSessions(context, emptyList())
                         }
                     },
                     onDismiss = { showClearDialog = false },
@@ -414,7 +579,7 @@ fun HistoryScreen() {
 
                             DetailRow(
                                 "开始时间",
-                                session.timestamp.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+                                session.timestamp?.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")) ?: "未知"
                             )
                             DetailRow("持续时长", formatTime(session.duration))
                             DetailRow("地点", session.location.ifEmpty { "无" })
@@ -446,8 +611,9 @@ fun HistoryScreen() {
 
                                 Button(
                                     onClick = {
-                                        editSession = session
-                                        isEditing = true
+                                        // 使用 ManualAddDialog 进行编辑
+                                        manualDateTime = session.timestamp ?: LocalDateTime.now()
+                                        manualDurationSeconds = session.duration
                                         remarkInput = session.remark
                                         locationInput = session.location
                                         watchedMovie = session.watchedMovie
@@ -455,10 +621,14 @@ fun HistoryScreen() {
                                         rating = session.rating
                                         mood = session.mood
                                         props = session.props
-                                        showDetailsDialog = true
+                                        editSession = session
+                                        isEditing = true
+                                        showManualAddDialog = true
                                         sessionToView = null
                                     },
-                                    modifier = Modifier.height(44.dp),
+                                    modifier = Modifier
+                                        .weight(1f)
+                                        .height(44.dp),
                                     shape = RoundedCornerShape(18.dp)
                                 ) {
                                     Icon(Icons.Rounded.Edit, contentDescription = null)
@@ -471,9 +641,13 @@ fun HistoryScreen() {
                 }
             }
 
-            // 编辑 / 新增 复用新版 DetailsDialog
-            DetailsDialog(
-                show = showDetailsDialog,
+            // 手动添加记录弹窗
+            ManualAddDialog(
+                show = showManualAddDialog,
+                selectedDateTime = manualDateTime,
+                onSelectedDateTimeChange = { manualDateTime = it },
+                durationSeconds = manualDurationSeconds,
+                onDurationSecondsChange = { manualDurationSeconds = it },
                 remark = remarkInput,
                 onRemarkChange = { remarkInput = it },
                 location = locationInput,
@@ -488,11 +662,15 @@ fun HistoryScreen() {
                 onRatingChange = { rating = it },
                 mood = mood,
                 onMoodChange = { mood = it },
+                customMoods = customOptions.moods,
+                customProps = customOptions.props,
                 onConfirm = {
                     if (isEditing && editSession != null) {
                         val index = sessions.indexOf(editSession)
                         if (index != -1) {
-                            sessions[index] = editSession!!.copy(
+                            sessions[index] = Session(
+                                timestamp = manualDateTime,
+                                duration = manualDurationSeconds,
                                 remark = remarkInput,
                                 location = locationInput,
                                 watchedMovie = watchedMovie,
@@ -502,20 +680,40 @@ fun HistoryScreen() {
                                 props = props
                             )
                         }
+                    } else {
+                        // 新增模式：添加新记录
+                        val newSession = Session(
+                            timestamp = manualDateTime,
+                            duration = manualDurationSeconds,
+                            remark = remarkInput,
+                            location = locationInput,
+                            watchedMovie = watchedMovie,
+                            climax = climax,
+                            rating = rating,
+                            mood = mood,
+                            props = props
+                        )
+                        sessions.add(0, newSession)
                     }
+
+                    val sortedSessions = sessions.sortedByDescending { it.timestamp }
+                    sessions.clear()
+                    sessions.addAll(sortedSessions)
 
                     scope.launch {
-                        SessionRepository.saveSessions(context, sessions)
+                        SessionRepository.saveSessions(context, sortedSessions)
                     }
 
-                    // 重置状态
-                    showDetailsDialog = false
+                    showManualAddDialog = false
+                    manualDateTime = LocalDateTime.now()
+                    manualDurationSeconds = 0
                     isEditing = false
                     editSession = null
-                    // 可以不重置输入框，因为下次编辑会覆盖
                 },
                 onDismiss = {
-                    showDetailsDialog = false
+                    showManualAddDialog = false
+                    manualDateTime = LocalDateTime.now()
+                    manualDurationSeconds = 0
                     isEditing = false
                     editSession = null
                 }

--- a/app/src/main/java/me/neko/nzhelper/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/me/neko/nzhelper/ui/screens/HomeScreen.kt
@@ -36,13 +36,12 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.LargeFlexibleTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
@@ -51,7 +50,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -75,50 +73,50 @@ import java.time.LocalDateTime
 
 
 @OptIn(
-    ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class,
-    ExperimentalMaterial3ExpressiveApi::class
+    ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class
 )
 @Composable
 fun HomeScreen() {
     val context = LocalContext.current
+    val appContext = remember(context) { context.applicationContext }
     val scope = rememberCoroutineScope()
     val scrollBehavior =
         TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState())
 
     // 绑定 Service
-    val serviceIntent = remember { Intent(context, TimerService::class.java) }
+    val serviceIntent = remember(appContext) { Intent(appContext, TimerService::class.java) }
     var timerService by remember { mutableStateOf<TimerService?>(null) }
+    var isServiceBound by remember { mutableStateOf(false) }
     val connection = remember {
         object : ServiceConnection {
             override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
                 timerService = (binder as TimerService.LocalBinder).getService()
+                isServiceBound = true
             }
 
             override fun onServiceDisconnected(name: ComponentName?) {
                 timerService = null
+                isServiceBound = false
             }
         }
     }
 
-    // 启动并绑定服务
+    // 仅绑定服务，避免首次进入页面就自动开始计时
     LaunchedEffect(Unit) {
-        ContextCompat.startForegroundService(
-            context,
-            serviceIntent.apply { action = TimerService.ACTION_START }
-        )
-        context.bindService(serviceIntent, connection, Context.BIND_AUTO_CREATE)
+        isServiceBound = appContext.bindService(serviceIntent, connection, Context.BIND_AUTO_CREATE)
     }
-    DisposableEffect(Unit) {
-        onDispose { context.unbindService(connection) }
+    DisposableEffect(appContext, connection, isServiceBound) {
+        onDispose {
+            if (isServiceBound) {
+                appContext.unbindService(connection)
+                isServiceBound = false
+            }
+        }
     }
 
-    // 订阅 elapsedSec
-    val elapsedSeconds by timerService
-        ?.elapsedSec
-        ?.collectAsState(initial = 0)
-        ?: remember { mutableIntStateOf(0) }
+    val elapsedSeconds = timerService?.elapsedSec?.collectAsState(initial = 0)?.value ?: 0
+    val isRunning = timerService?.isRunning?.collectAsState(initial = false)?.value ?: false
 
-    var isRunning by remember { mutableStateOf(false) }
     var showConfirmDialog by remember { mutableStateOf(false) }
     var showDetailsDialog by remember { mutableStateOf(false) }
 
@@ -132,6 +130,12 @@ fun HomeScreen() {
 
     val sessions = remember { mutableStateListOf<Session>() }
 
+    // 加载自定义选项（带默认值）
+    var customOptions by remember { mutableStateOf(me.neko.nzhelper.data.CustomOptions()) }
+    LaunchedEffect(Unit) {
+        customOptions = SessionRepository.loadCustomOptions(context)
+    }
+
     // 加载历史（仍然需要加载，用于后续保存新记录时合并）
     LaunchedEffect(Unit) {
         val loaded = SessionRepository.loadSessions(context)
@@ -139,16 +143,10 @@ fun HomeScreen() {
         sessions.addAll(loaded)
     }
 
-    // 控制 Service 启停
-    LaunchedEffect(isRunning) {
-        val action = if (isRunning) TimerService.ACTION_START else TimerService.ACTION_PAUSE
-        context.startService(serviceIntent.apply { this.action = action })
-    }
-
     Scaffold(
         topBar = {
-            LargeFlexibleTopAppBar(
-                title = { Text(text = "牛子小助手") },
+            TopAppBar(
+                title = { Text(text = "牛牛小助手") },
                 scrollBehavior = scrollBehavior
             )
         },
@@ -175,11 +173,11 @@ fun HomeScreen() {
                         verticalArrangement = Arrangement.spacedBy(24.dp),
                     ) {
                         Text(
-                            text = "记录新的手艺活",
+                            text = "记录",
                             style = MaterialTheme.typography.headlineMedium
                         )
                         Text(
-                            text = "准备开始",
+                            text = if (isRunning) "开始啦~" else "准备开始……",
                             style = MaterialTheme.typography.headlineLarge
                         )
                         Text(
@@ -189,11 +187,23 @@ fun HomeScreen() {
                         )
 
                         Row(
-                            horizontalArrangement = Arrangement.spacedBy(48.dp), // 间距稍大，因为点击区域更大
+                            horizontalArrangement = Arrangement.spacedBy(48.dp),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
                             IconButton(
-                                onClick = { isRunning = !isRunning },
+                                onClick = {
+                                    val action = if (isRunning) {
+                                        TimerService.ACTION_PAUSE
+                                    } else {
+                                        TimerService.ACTION_START
+                                    }
+                                    ContextCompat.startForegroundService(
+                                        appContext,
+                                        Intent(appContext, TimerService::class.java).apply {
+                                            this.action = action
+                                        }
+                                    )
+                                },
                                 modifier = Modifier
                                     .size(64.dp)
                                     .background(
@@ -252,7 +262,7 @@ fun HomeScreen() {
                     },
                     text = {
                         Text(
-                            text = "要结束对牛牛的爱抚了吗？",
+                            text = "真的要结束了吗？",
                             style = MaterialTheme.typography.bodyLarge,
                             modifier = Modifier.fillMaxWidth(),
                             textAlign = TextAlign.Center
@@ -276,14 +286,19 @@ fun HomeScreen() {
                                     contentColor = MaterialTheme.colorScheme.secondary
                                 )
                             ) {
-                                Text("再坚持一下")
+                                Text("还不可以…")
                             }
 
                             Button(
                                 onClick = {
                                     showConfirmDialog = false
                                     showDetailsDialog = true
-                                    isRunning = false
+                                    ContextCompat.startForegroundService(
+                                        appContext,
+                                        Intent(appContext, TimerService::class.java).apply {
+                                            action = TimerService.ACTION_PAUSE
+                                        }
+                                    )
                                 },
                                 modifier = Modifier.height(44.dp),
                                 shape = RoundedCornerShape(18.dp),
@@ -292,7 +307,7 @@ fun HomeScreen() {
                                     contentColor = MaterialTheme.colorScheme.error
                                 )
                             ) {
-                                Text("燃尽了")
+                                Text("燃尽了……")
                             }
                         }
                     },
@@ -317,6 +332,8 @@ fun HomeScreen() {
                 onRatingChange = { rating = it },
                 mood = mood,
                 onMoodChange = { mood = it },
+                customMoods = customOptions.moods,
+                customProps = customOptions.props,
                 onConfirm = {
                     val now = LocalDateTime.now()
                     val session = Session(
@@ -332,11 +349,10 @@ fun HomeScreen() {
                     )
                     sessions.add(session)
                     scope.launch {
-                        SessionRepository.saveSessions(context, sessions)
+                        SessionRepository.saveSessions(context, sessions.toList())
                     }
 
                     // 重置所有输入状态
-                    isRunning = false
                     remarkInput = ""
                     locationInput = ""
                     watchedMovie = false
@@ -347,8 +363,10 @@ fun HomeScreen() {
                     showDetailsDialog = false
 
                     // 停止计时服务
-                    context.startService(
-                        serviceIntent.apply { action = TimerService.ACTION_STOP }
+                    appContext.startService(
+                        Intent(appContext, TimerService::class.java).apply {
+                            action = TimerService.ACTION_STOP
+                        }
                     )
                 },
                 onDismiss = {

--- a/app/src/main/java/me/neko/nzhelper/ui/screens/OpenSource.kt
+++ b/app/src/main/java/me/neko/nzhelper/ui/screens/OpenSource.kt
@@ -16,13 +16,12 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.LargeFlexibleTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
@@ -36,7 +35,7 @@ import androidx.core.net.toUri
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun OpenSourceScreen(
     navController: NavHostController
@@ -47,7 +46,7 @@ fun OpenSourceScreen(
 
     Scaffold(
         topBar = {
-            LargeFlexibleTopAppBar(
+            TopAppBar(
                 title = { Text("开放源代码") },
                 navigationIcon = {
                     IconButton(onClick = { navController.popBackStack() }) {

--- a/app/src/main/java/me/neko/nzhelper/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/me/neko/nzhelper/ui/screens/SettingsScreen.kt
@@ -1,5 +1,8 @@
 package me.neko.nzhelper.ui.screens
 
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -11,36 +14,150 @@ import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
-import androidx.compose.material3.LargeFlexibleTopAppBar
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
+import kotlinx.coroutines.launch
+import me.neko.nzhelper.data.CustomOptions
+import me.neko.nzhelper.data.SessionRepository
+import me.neko.nzhelper.ui.dialog.CustomOptionsDialog
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(
     navController: NavController
 ) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState())
+
+    var customOptions by remember { mutableStateOf<CustomOptions?>(null) }
+    var showMoodDialog by remember { mutableStateOf(false) }
+    var showPropsDialog by remember { mutableStateOf(false) }
+    
+    // 菜单和导入导出
+    var showMenu by remember { mutableStateOf(false) }
+    
+    val importOptionsLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocument()
+    ) { uri: android.net.Uri? ->
+        uri?.let { importUri ->
+            scope.launch {
+                try {
+                    context.contentResolver.openInputStream(importUri)?.use { inputStream ->
+                        val jsonStr = inputStream.bufferedReader().readText()
+                        val importedOptions = com.google.gson.Gson().fromJson(
+                            jsonStr,
+                            object : com.google.gson.reflect.TypeToken<CustomOptions>() {}.type
+                        ) as? CustomOptions
+                        
+                        if (importedOptions != null) {
+                            SessionRepository.saveCustomOptions(context, importedOptions)
+                            customOptions = importedOptions
+                            Toast.makeText(context, "成功导入自定义选项", Toast.LENGTH_SHORT).show()
+                        } else {
+                            Toast.makeText(context, "导入失败：文件格式不正确", Toast.LENGTH_SHORT).show()
+                        }
+                    }
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                    Toast.makeText(context, "导入失败：${e.message}", Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+    }
+
+    val exportOptionsLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.CreateDocument("application/json")
+    ) { uri: android.net.Uri? ->
+        uri?.let { exportUri ->
+            scope.launch {
+                try {
+                    context.contentResolver.openOutputStream(exportUri)?.use { outputStream ->
+                        val json = com.google.gson.Gson().toJson(customOptions ?: CustomOptions())
+                        outputStream.write(json.toByteArray())
+                        Toast.makeText(context, "成功导出自定义选项", Toast.LENGTH_SHORT).show()
+                    }
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                    Toast.makeText(context, "导出失败：${e.message}", Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+    }
+
+    // 加载自定义选项
+    LaunchedEffect(Unit) {
+        customOptions = SessionRepository.loadCustomOptions(context)
+    }
 
     Scaffold(
         topBar = {
-            LargeFlexibleTopAppBar(
+            CenterAlignedTopAppBar(
                 title = { Text("设置") },
+                actions = {
+                    IconButton(onClick = { showMenu = true }) {
+                        Icon(Icons.Default.MoreVert, contentDescription = "菜单")
+                    }
+                    
+                    DropdownMenu(
+                        expanded = showMenu,
+                        onDismissRequest = { showMenu = false }
+                    ) {
+                        DropdownMenuItem(
+                            text = { Text("导入自定义选项") },
+                            onClick = {
+                                showMenu = false
+                                importOptionsLauncher.launch(arrayOf("application/json"))
+                            }
+                        )
+                        DropdownMenuItem(
+                            text = { Text("导出自定义选项") },
+                            onClick = {
+                                showMenu = false
+                                exportOptionsLauncher.launch("custom_options.json")
+                            }
+                        )
+                        DropdownMenuItem(
+                            text = { Text("重置为默认值") },
+                            onClick = {
+                                showMenu = false
+                                scope.launch {
+                                    val defaultOptions = CustomOptions()
+                                    SessionRepository.saveCustomOptions(context, defaultOptions)
+                                    customOptions = defaultOptions
+                                    Toast.makeText(context, "已重置为默认选项", Toast.LENGTH_SHORT).show()
+                                }
+                            }
+                        )
+                    }
+                },
                 scrollBehavior = scrollBehavior
             )
         },
@@ -55,23 +172,79 @@ fun SettingsScreen(
             ListItem(
                 modifier = Modifier
                     .fillMaxWidth()
+                    .clickable { showMoodDialog = true },
+                headlineContent = {
+                    Text(text = "添加更多心情", style = MaterialTheme.typography.titleMedium)
+                },
+                supportingContent = {
+                    customOptions?.let { options ->
+                        Text(text = "当前：${options.moods.joinToString("、")}")
+                    }
+                }
+            )
+
+            ListItem(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { showPropsDialog = true },
+                headlineContent = {
+                    Text(text = "添加更多道具", style = MaterialTheme.typography.titleMedium)
+                },
+                supportingContent = {
+                    customOptions?.let { options ->
+                        Text(text = "当前：${options.props.joinToString("、")}")
+                    }
+                }
+            )
+
+            ListItem(
+                modifier = Modifier
+                    .fillMaxWidth()
                     .clickable {
                         navController.navigate("about")
                     },
-                leadingContent = {
-                    Icon(
-                        imageVector = Icons.Outlined.Info,
-                        contentDescription = null,
-                    )
-                },
                 headlineContent = {
                     Text(text = "关于", style = MaterialTheme.typography.titleMedium)
                 }
             )
+
             Spacer(modifier = Modifier.weight(1f))
         }
-
     }
+
+    // 自定义心情弹窗
+    CustomOptionsDialog(
+        show = showMoodDialog,
+        title = "心情",
+        initialOptions = customOptions?.moods ?: emptyList(),
+        onConfirm = { newMoods ->
+            scope.launch {
+                val newOptions = customOptions?.copy(moods = newMoods) ?: CustomOptions(moods = newMoods)
+                SessionRepository.saveCustomOptions(context, newOptions)
+                customOptions = newOptions
+                Toast.makeText(context, "心情选项已保存", Toast.LENGTH_SHORT).show()
+            }
+            showMoodDialog = false
+        },
+        onDismiss = { showMoodDialog = false }
+    )
+
+    // 自定义道具弹窗
+    CustomOptionsDialog(
+        show = showPropsDialog,
+        title = "道具",
+        initialOptions = customOptions?.props ?: emptyList(),
+        onConfirm = { newProps ->
+            scope.launch {
+                val newOptions = customOptions?.copy(props = newProps) ?: CustomOptions(props = newProps)
+                SessionRepository.saveCustomOptions(context, newOptions)
+                customOptions = newOptions
+                Toast.makeText(context, "道具选项已保存", Toast.LENGTH_SHORT).show()
+            }
+            showPropsDialog = false
+        },
+        onDismiss = { showPropsDialog = false }
+    )
 }
 
 @Preview(showBackground = true)

--- a/app/src/main/java/me/neko/nzhelper/ui/screens/statistics/StatisticsScreen.kt
+++ b/app/src/main/java/me/neko/nzhelper/ui/screens/statistics/StatisticsScreen.kt
@@ -28,12 +28,11 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
-import androidx.compose.material3.LargeFlexibleTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
@@ -56,61 +55,80 @@ import androidx.compose.ui.unit.dp
 import me.neko.nzhelper.data.Session
 import me.neko.nzhelper.data.SessionRepository
 import java.time.DayOfWeek
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.YearMonth
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
+import java.time.temporal.TemporalAdjusters
 import java.util.Locale
 import kotlin.random.Random
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun StatisticsScreen() {
     val context = LocalContext.current
     val sessions = remember { mutableStateListOf<Session>() }
     LaunchedEffect(Unit) {
-        val loaded = SessionRepository.loadSessions(context)
-        sessions.clear()
-        sessions.addAll(loaded)
+        try {
+            val loaded = SessionRepository.loadSessions(context)
+            sessions.clear()
+            sessions.addAll(loaded)
+        } catch (e: Exception) {
+            e.printStackTrace()
+            // 如果加载失败，保持空列表
+            sessions.clear()
+        }
     }
 
     val currentTime = LocalDateTime.now()
+    
+    // 使用 derivedStateOf 来确保只在 sessions 变化时才重新计算
+    val validSessions by remember {
+        derivedStateOf {
+            sessions.filter { it.timestamp != null }
+        }
+    }
+    
     val weekStats by remember {
         derivedStateOf {
-            calculatePeriodStats(sessions, PeriodType.WEEK, currentTime)
+            calculatePeriodStats(validSessions, PeriodType.WEEK, currentTime)
         }
     }
     val monthStats by remember {
         derivedStateOf {
-            calculatePeriodStats(sessions, PeriodType.MONTH, currentTime)
+            calculatePeriodStats(validSessions, PeriodType.MONTH, currentTime)
         }
     }
     val yearStats by remember {
         derivedStateOf {
-            calculatePeriodStats(sessions, PeriodType.YEAR, currentTime)
+            calculatePeriodStats(validSessions, PeriodType.YEAR, currentTime)
         }
     }
 
     val weekCount by remember {
         derivedStateOf {
-            sessions.count {
-                it.timestamp >= currentTime.minusDays(currentTime.dayOfWeek.value.toLong() - 1)
+            validSessions.count { session ->
+                session.timestamp != null && 
+                session.timestamp >= currentTime.minusDays(currentTime.dayOfWeek.value.toLong() - 1)
                     .withHour(0).withMinute(0).withSecond(0).withNano(0)
             }
         }
     }
     val monthCount by remember {
         derivedStateOf {
-            sessions.count {
-                it.timestamp >= currentTime.withDayOfMonth(1)
+            validSessions.count { session ->
+                session.timestamp != null &&
+                session.timestamp >= currentTime.withDayOfMonth(1)
                     .withHour(0).withMinute(0).withSecond(0).withNano(0)
             }
         }
     }
     val yearCount by remember {
         derivedStateOf {
-            sessions.count {
-                it.timestamp >= currentTime.withDayOfYear(1)
+            validSessions.count { session ->
+                session.timestamp != null &&
+                session.timestamp >= currentTime.withDayOfYear(1)
                     .withHour(0).withMinute(0).withSecond(0).withNano(0)
             }
         }
@@ -119,11 +137,11 @@ fun StatisticsScreen() {
     // 计算总体统计
     val totalStats by remember {
         derivedStateOf {
-            if (sessions.isEmpty()) {
+            if (validSessions.isEmpty()) {
                 Triple(0, 0, 0f)
             } else {
-                val totalCount = sessions.size
-                val totalSeconds = sessions.sumOf { it.duration }
+                val totalCount = validSessions.size
+                val totalSeconds = validSessions.sumOf { it.duration }
                 val avgMinutes = totalSeconds.toFloat() / (60 * totalCount)
                 Triple(totalCount, totalSeconds, avgMinutes)
             }
@@ -144,9 +162,9 @@ fun StatisticsScreen() {
                 val weekDays = (0..6).map { monday.plusDays(it.toLong()) }
 
                 // 按日期分组统计
-                val statsMap = sessions
-                    .filter { it.timestamp.toLocalDate() >= monday }
-                    .groupBy { it.timestamp.toLocalDate() }
+                val statsMap = validSessions
+                    .filter { it.timestamp!!.toLocalDate() >= monday }
+                    .groupBy { it.timestamp!!.toLocalDate() }
                     .mapValues { entry ->
                         DailyStat(
                             count = entry.value.size,
@@ -180,12 +198,12 @@ fun StatisticsScreen() {
                 val now = LocalDateTime.now()
                 val firstDayOfMonth = now.withDayOfMonth(1).toLocalDate()
 
-                sessions
+                validSessions
                     .filter {
-                        val date = it.timestamp.toLocalDate()
+                        val date = it.timestamp!!.toLocalDate()
                         date >= firstDayOfMonth
                     }
-                    .groupBy { it.timestamp.toLocalDate() }
+                    .groupBy { it.timestamp!!.toLocalDate() }
                     .mapValues { entry ->
                         entry.value.sumOf { it.duration } / 60f
                     }
@@ -207,9 +225,9 @@ fun StatisticsScreen() {
                 val currentYear = now.year
 
                 // 按年月分组统计时长（秒 → 分钟）
-                val statsMap = sessions
-                    .filter { it.timestamp.year == currentYear }
-                    .groupBy { YearMonth.from(it.timestamp) }
+                val statsMap = validSessions
+                    .filter { it.timestamp!!.year == currentYear }
+                    .groupBy { YearMonth.from(it.timestamp!!) }
                     .mapValues { entry ->
                         entry.value.sumOf { it.duration } / 60f
                     }
@@ -243,19 +261,24 @@ fun StatisticsScreen() {
 
     val latestSessionInfo by remember {
         derivedStateOf {
-            if (sessions.isEmpty()) {
+            if (validSessions.isEmpty()) {
                 null
             } else {
-                val latest = sessions.maxByOrNull { it.timestamp }!!
-                val lastDate = latest.timestamp.toLocalDate()
+                val latest = validSessions.maxByOrNull { it.timestamp!! }
+                val lastDate = latest!!.timestamp!!.toLocalDate()
                 val daysAgo = ChronoUnit.DAYS.between(lastDate, LocalDateTime.now().toLocalDate())
-
+                    
+                // 计算今天（最后一次记录日期）的记录次数
+                val todayCount = validSessions.count { 
+                    it.timestamp?.toLocalDate() == lastDate 
+                }
+    
                 // 主日期显示
                 val displayDate = when (daysAgo) {
                     0L -> "今天"
                     1L -> "昨天"
                     else -> {
-                        val dateFmt = lastDate.format(DateTimeFormatter.ofPattern("M月d日"))
+                        val dateFmt = lastDate.format(DateTimeFormatter.ofPattern("M 月 d 日"))
                         val dayOfWeek = when (lastDate.dayOfWeek) {
                             DayOfWeek.MONDAY -> "星期一"
                             DayOfWeek.TUESDAY -> "星期二"
@@ -269,40 +292,53 @@ fun StatisticsScreen() {
                         "$dateFmt $dayOfWeek"
                     }
                 }
-
+    
                 // 时间
                 val time = latest.timestamp.format(
                     DateTimeFormatter.ofPattern("a h:mm").withLocale(Locale.CHINA)
                 )
-
+    
                 fun randomOf(vararg list: String): String =
                     list[Random.nextInt(list.size)]
-
-                val breakDetail = when (daysAgo) {
-                    0L -> randomOf(
+    
+                // 判断是否频率过高（今天 >= 3 次）
+                val isTooFrequent = daysAgo == 0L && todayCount >= 3
+    
+                val breakDetail = when {
+                    // 频率过高时的专门提醒
+                    isTooFrequent -> randomOf(
+                        "今天已经很多次了，要注意休息哦～",
+                        "释放太多会伤身体的，科学适度哦~",
+                        "今天有点频繁了呢，早点休息吧",
+                        "今天的活动就到此为止吧~",
+                        "警告: 行动点耗尽!"
+                    )
+                    
+                    // 正常今天的消息
+                    daysAgo == 0L -> randomOf(
                         "今日已交作业",
                         "今天完成了释放指标",
                         "已完成今日份输出",
-                        "今天没忍住，已记录"
+                        "今天没忍住，已记录~"
                     )
-
-                    1L -> randomOf(
+    
+                    daysAgo == 1L -> randomOf(
                         "昨天完成了一次",
                         "昨日成功部署",
                         "昨天交过作业了",
                         "昨天有过记录"
                     )
-
-                    2L -> randomOf(
+    
+                    daysAgo == 2L -> randomOf(
                         "已经鸽了 2 天",
                         "空窗 2 天中",
                         "连续摆烂 2 天"
                     )
-
+    
                     else -> {
                         val startFmt =
-                            lastDate.plusDays(1).format(DateTimeFormatter.ofPattern("M月d日"))
-
+                            lastDate.plusDays(1).format(DateTimeFormatter.ofPattern("M 月 d 日"))
+    
                         randomOf(
                             "已经鸽了 $daysAgo 天（自 $startFmt 起）",
                             "空窗 $daysAgo 天了（$startFmt 开始）",
@@ -310,13 +346,14 @@ fun StatisticsScreen() {
                         )
                     }
                 }
-
+    
                 LatestSessionInfo(
                     daysAgo = daysAgo,
                     displayDate = displayDate,
                     time = time,
                     durationSeconds = latest.duration,
-                    breakDetail = breakDetail
+                    breakDetail = breakDetail,
+                    todayCount = todayCount
                 )
             }
         }
@@ -326,7 +363,7 @@ fun StatisticsScreen() {
         TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState())
     Scaffold(
         topBar = {
-            LargeFlexibleTopAppBar(
+            TopAppBar(
                 title = { Text("统计") },
                 scrollBehavior = scrollBehavior
             )
@@ -385,6 +422,23 @@ fun StatisticsScreen() {
                                 yearCount = yearCount,
                                 modifier = Modifier.fillMaxWidth()
                             )
+                        }
+                    }
+
+                    // 贡献热力图
+                    item {
+                        ElevatedCard(
+                            modifier = Modifier.fillMaxWidth(),
+                            elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+                        ) {
+                            Column(
+                                modifier = Modifier.padding(16.dp)
+                            ) {
+                                ContributionHeatmap(
+                                    sessions = validSessions,
+                                    modifier = Modifier.fillMaxWidth()
+                                )
+                            }
                         }
                     }
 
@@ -581,25 +635,28 @@ private fun calculatePeriodStats(
     sessions: List<Session>,
     type: PeriodType,
     now: LocalDateTime
-): Pair<Int, Float> { // Pair<总时长秒数, 平均单次时长分钟>
+): Pair<Int, Float> { // Pair<总时长秒数，平均单次时长分钟>
     val filtered = sessions.filter { session ->
+        // 确保 timestamp 不为 null
+        val timestamp = session.timestamp ?: return@filter false
+        
         when (type) {
             PeriodType.WEEK -> {
                 val weekStart = now.minusDays(now.dayOfWeek.value.toLong() - 1) // 本周一 00:00
                     .withHour(0).withMinute(0).withSecond(0).withNano(0)
-                session.timestamp >= weekStart
+                timestamp >= weekStart
             }
 
             PeriodType.MONTH -> {
                 val monthStart = now.withDayOfMonth(1)
                     .withHour(0).withMinute(0).withSecond(0).withNano(0)
-                session.timestamp >= monthStart
+                timestamp >= monthStart
             }
 
             PeriodType.YEAR -> {
                 val yearStart = now.withDayOfYear(1)
                     .withHour(0).withMinute(0).withSecond(0).withNano(0)
-                session.timestamp >= yearStart
+                timestamp >= yearStart
             }
         }
     }
@@ -763,10 +820,32 @@ private fun LatestSessionCard(
 
                     Spacer(modifier = Modifier.height(20.dp))
 
-                    val (textColor, backgroundColor) = when (latestInfo.daysAgo) {
-                        0L -> MaterialTheme.colorScheme.primary to MaterialTheme.colorScheme.primaryContainer
-                        1L -> MaterialTheme.colorScheme.secondary to MaterialTheme.colorScheme.secondaryContainer
-                        else -> MaterialTheme.colorScheme.error to MaterialTheme.colorScheme.errorContainer
+                    // 根据空窗天数和频率决定背景颜色
+                    val backgroundColor = when {
+                        // 今天记录次数 >= 3 次，红色背景警告
+                        latestInfo.daysAgo == 0L && latestInfo.todayCount >= 3 -> 
+                            MaterialTheme.colorScheme.errorContainer
+                        // 今天记录次数 < 3 次，粉色背景
+                        latestInfo.daysAgo == 0L -> 
+                            MaterialTheme.colorScheme.primaryContainer
+                        // 昨天，柔和粉色背景
+                        latestInfo.daysAgo == 1L -> 
+                            MaterialTheme.colorScheme.secondaryContainer
+                        // 超过 1 天，粉色背景
+                        else -> 
+                            MaterialTheme.colorScheme.tertiaryContainer
+                    }
+                    
+                    // 文字颜色根据背景自动适配
+                    val textColor = when {
+                        latestInfo.daysAgo == 0L && latestInfo.todayCount >= 3 -> 
+                            MaterialTheme.colorScheme.onErrorContainer
+                        latestInfo.daysAgo == 0L -> 
+                            MaterialTheme.colorScheme.onPrimaryContainer
+                        latestInfo.daysAgo == 1L -> 
+                            MaterialTheme.colorScheme.onSecondaryContainer
+                        else -> 
+                            MaterialTheme.colorScheme.onTertiaryContainer
                     }
 
                     Surface(
@@ -799,7 +878,8 @@ private data class LatestSessionInfo(
     val displayDate: String,
     val time: String,
     val durationSeconds: Int,
-    val breakDetail: String
+    val breakDetail: String,
+    val todayCount: Int = 0
 )
 
 // 条形图
@@ -899,6 +979,180 @@ private fun YAxis(
             color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)
         )
     }
+}
+
+// GitHub 风格的贡献热力图
+@Composable
+private fun ContributionHeatmap(
+    sessions: List<Session>,
+    modifier: Modifier = Modifier
+) {
+    if (sessions.isEmpty()) {
+        Box(
+            modifier = modifier
+                .fillMaxWidth()
+                .height(120.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                "暂无数据",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        return
+    }
+
+    val now = LocalDateTime.now()
+    
+    // 计算固定 17 周的日期范围
+    val weeksCount = 17
+    val endDate = now.toLocalDate()
+    val startDate = endDate.minusWeeks((weeksCount - 1).toLong()).with(TemporalAdjusters.previousOrSame(java.time.DayOfWeek.SUNDAY))
+    
+    // 按日期分组统计次数
+    val sessionsByDate = sessions
+        .filter { it.timestamp != null }
+        .groupBy { it.timestamp!!.toLocalDate() }
+        .mapValues { it.value.size }
+    
+    // 找到最大次数用于颜色分级
+    val maxCount = sessionsByDate.values.maxOrNull() ?: 0
+    
+    Column(
+        modifier = modifier
+    ) {
+        // 热力图网格（7 行 x 17 列）
+        val weeks = mutableListOf<List<LocalDate>>()
+        var currentWeek = mutableListOf<LocalDate>()
+        
+        // 生成固定 17 周的日期
+        var date = startDate
+        repeat(weeksCount) {
+            currentWeek.clear()
+            for (day in 0 until 7) {
+                currentWeek.add(date.plusDays(day.toLong()))
+            }
+            weeks.add(currentWeek.toList())
+            date = date.plusWeeks(1)
+        }
+        
+        // 使用 BoxWithConstraints 获取可用宽度，动态计算方块大小
+        BoxWithConstraints(
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            val availableWidth = maxWidth
+            val spacing = 3.dp
+            val totalSpacing = spacing * (weeksCount - 1) // 16 个间隔
+            val cellWidth = (availableWidth - totalSpacing) / weeksCount
+            
+            // 按周显示（横向排列周，每列 7 个方块）
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.Center
+            ) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(spacing)
+                ) {
+                    weeks.forEach { week ->
+                        Column(
+                            verticalArrangement = Arrangement.spacedBy(spacing)
+                        ) {
+                            for (row in 0 until 7) {
+                                if (row < week.size) {
+                                    val currentDate = week[row]
+                                    val count = sessionsByDate[currentDate] ?: 0
+                                    val isFuture = currentDate > endDate
+                                    
+                                    HeatmapCell(
+                                        count = count,
+                                        maxCount = maxCount,
+                                        isFuture = isFuture,
+                                        modifier = Modifier
+                                            .width(cellWidth)
+                                            .height(cellWidth)
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        
+        // 月份标签（底部，热力图外面）
+        Spacer(modifier = Modifier.height(4.dp))
+        MonthLabels(weeks = weeks, weeksCount = weeksCount)
+    }
+}
+
+@Composable
+private fun MonthLabels(
+    weeks: List<List<LocalDate>>,
+    weeksCount: Int
+) {
+    val monthStartLabels = buildMap<Int, String> {
+        weeks.forEachIndexed { index, week ->
+            val firstDayOfMonth = week.firstOrNull { it.dayOfMonth == 1 } ?: return@forEachIndexed
+            put(index, "${firstDayOfMonth.monthValue}月")
+        }
+    }
+
+    BoxWithConstraints(
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        val spacing = 3.dp
+        val totalSpacing = spacing * (weeksCount - 1)
+        val cellWidth = (maxWidth - totalSpacing) / weeksCount
+
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(spacing)
+        ) {
+            repeat(weeksCount) { index ->
+                Box(
+                    modifier = Modifier.width(cellWidth)
+                ) {
+                    monthStartLabels[index]?.let { label ->
+                        Text(
+                            text = label,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
+                            modifier = Modifier.align(Alignment.CenterStart)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun HeatmapCell(
+    count: Int,
+    maxCount: Int,
+    isFuture: Boolean,
+    modifier: Modifier = Modifier
+) {
+    val color = when {
+        isFuture -> MaterialTheme.colorScheme.surface
+        count == 0 -> MaterialTheme.colorScheme.surfaceContainerHighest
+        maxCount == 0 -> MaterialTheme.colorScheme.primaryContainer
+        else -> {
+            val ratio = count.toFloat() / maxCount
+            when {
+                ratio < 0.25 -> MaterialTheme.colorScheme.primaryContainer
+                ratio < 0.5 -> MaterialTheme.colorScheme.primary.copy(alpha = 0.6f)
+                ratio < 0.75 -> MaterialTheme.colorScheme.primary.copy(alpha = 0.8f)
+                else -> MaterialTheme.colorScheme.primary
+            }
+        }
+    }
+    
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(2.dp))
+            .background(color)
+    )
 }
 
 @Composable

--- a/app/src/main/java/me/neko/nzhelper/ui/service/TimerService.kt
+++ b/app/src/main/java/me/neko/nzhelper/ui/service/TimerService.kt
@@ -1,22 +1,20 @@
 package me.neko.nzhelper.ui.service
 
 import android.Manifest
+import android.annotation.SuppressLint
+import android.app.Notification
 import android.app.Service
 import android.content.Intent
-import android.os.IBinder
 import android.os.Binder
-import android.os.Handler
-import android.os.Looper
-import android.app.Notification
-import android.annotation.SuppressLint
+import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo
 import android.os.Build
-import androidx.annotation.RequiresApi
-import androidx.annotation.RequiresPermission
-
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
-
+import androidx.core.content.ContextCompat
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -30,13 +28,14 @@ class TimerService : Service() {
     private val binder = LocalBinder()
     private val _elapsedSec = MutableStateFlow(0)
     val elapsedSec: StateFlow<Int> = _elapsedSec.asStateFlow()
+    private val _isRunning = MutableStateFlow(false)
+    val isRunning: StateFlow<Boolean> = _isRunning.asStateFlow()
 
     private var startTimeMs: Long = 0L
     private var accumulatedSec: Int = 0
 
     private val handler = Handler(Looper.getMainLooper())
     private val tickRunnable = object : Runnable {
-        @RequiresPermission(Manifest.permission.POST_NOTIFICATIONS)
         override fun run() {
             val nowMs = System.currentTimeMillis()
             _elapsedSec.value = accumulatedSec + ((nowMs - startTimeMs) / 1000).toInt()
@@ -51,8 +50,6 @@ class TimerService : Service() {
         fun getService(): TimerService = this@TimerService
     }
 
-    @RequiresApi(Build.VERSION_CODES.Q)
-    @SuppressLint("ForegroundServiceType")
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         when (intent?.action) {
             ACTION_START -> startTimer()
@@ -63,22 +60,30 @@ class TimerService : Service() {
     }
 
     /** 启动计时并进入前台 */
-    @RequiresApi(Build.VERSION_CODES.Q)
     private fun startTimer() {
+        if (_isRunning.value) return
         if (startTimeMs == 0L) {
             startTimeMs = System.currentTimeMillis()
         }
+        _isRunning.value = true
+        handler.removeCallbacks(tickRunnable)
         handler.post(tickRunnable)
         val notif = buildNotification(_elapsedSec.value)
-        // 以 dataSync 类型运行前台服务
-        startForeground(NOTIF_ID, notif, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(NOTIF_ID, notif, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
+        } else {
+            @Suppress("DEPRECATION")
+            startForeground(NOTIF_ID, notif)
+        }
     }
 
     /** 暂停计时（仍可保留通知） */
     private fun pauseTimer() {
+        if (!_isRunning.value) return
         handler.removeCallbacks(tickRunnable)
         accumulatedSec = _elapsedSec.value
         startTimeMs = 0L
+        _isRunning.value = false
     }
 
     /** 停止并重置计时 */
@@ -89,6 +94,7 @@ class TimerService : Service() {
         accumulatedSec = 0
         startTimeMs = 0L
         _elapsedSec.value = 0
+        _isRunning.value = false
         // 取消前台状态并移除通知
         stopForeground(true)
         stopSelf()
@@ -105,14 +111,23 @@ class TimerService : Service() {
             .build()
     }
 
-    @RequiresPermission(Manifest.permission.POST_NOTIFICATIONS)
     private fun updateNotification(elapsed: Int) {
+        if (
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.POST_NOTIFICATIONS
+            ) != PackageManager.PERMISSION_GRANTED
+        ) {
+            return
+        }
         val notif = buildNotification(elapsed)
         NotificationManagerCompat.from(this).notify(NOTIF_ID, notif)
     }
 
     override fun onDestroy() {
         handler.removeCallbacks(tickRunnable)
+        _isRunning.value = false
         super.onDestroy()
     }
 

--- a/app/src/main/java/me/neko/nzhelper/ui/theme/Theme.kt
+++ b/app/src/main/java/me/neko/nzhelper/ui/theme/Theme.kt
@@ -2,15 +2,14 @@ package me.neko.nzhelper.ui.theme
 
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
-import androidx.compose.material3.MaterialExpressiveTheme
-import androidx.compose.material3.MotionScheme
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.graphics.Color
 
 private val DarkColorScheme = darkColorScheme(
     primary = Purple80,
@@ -34,7 +33,6 @@ private val LightColorScheme = lightColorScheme(
     */
 )
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun NzHelperTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
@@ -52,9 +50,8 @@ fun NzHelperTheme(
         else -> LightColorScheme
     }
 
-    MaterialExpressiveTheme(
+    MaterialTheme(
         colorScheme = colorScheme,
-        motionScheme = MotionScheme.expressive(),
         typography = Typography,
         content = content
     )

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Jun 11 12:02:50 CST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=file\:///D\:/Derry/AndroidStudioTool/gradle-8.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### 更多新feature

1. 在_历史_页面，增添了手动添加历史记录功能与菜单，可自定义各种选项，该菜单也可以用于对历史记录进行编辑；
<img width="270" height="600" alt="ae175824a7fa5ac3827c93fe4d06676b" src="https://github.com/user-attachments/assets/db28a1a5-aeef-44a7-85cd-efe0fcbebd51" />

2. 在 _统计_ 页面加入了直观的热力图（参考贡献热力图），便于直观统计频率，并做了一定的设备适配（没有在平板电脑调试，可能不起作用）；
<img width="270" height="600" alt="0e00d54247b4986da6c849f9b5c5f903" src="https://github.com/user-attachments/assets/531731ef-40b3-491e-ae10-cbd38135365f" />

3. 统计提示语与背景颜色会随当日次数改变，配套加入了一些新的温馨提示、警示，显示上的细节；
<img width="270" height="600" alt="05aa8962e99bc694378a2662b6038d7d" src="https://github.com/user-attachments/assets/4f444d6d-0fea-47f8-9738-bb9b0aaaa697" />

4. 可自定义心情、道具等（扩展了导入导出文件的结构，但向上兼容，支持导入旧数据格式）；
<img width="270" height="600" alt="b8142944408e529c3255a78a50f2991f" src="https://github.com/user-attachments/assets/e93537ac-e333-418f-b24b-7529bd96869c" />

5. 更改了一点措辞用语使之显得不那么雷霆（可忽略）；

这是我第一次向该项目提交 PR，也是在GitHub上第一次提交PR，欢迎指出需要调整的地方，这是学习的重要部分。相关改动已经经过了相当一段时间的实际使用和本地调试， 但可能仍有纰漏，请多指导😇