### PR TITLE
Add iOS app project

### DIFF
--- a/NZhelper.xcodeproj/project.pbxproj
+++ b/NZhelper.xcodeproj/project.pbxproj
@@ -1,0 +1,333 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXFileReference section */
+		C475677E2FBC498300A19C86 /* NZhelper.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NZhelper.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		C47567802FBC498300A19C86 /* NZhelper */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = NZhelper;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		C475677B2FBC498300A19C86 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		C47567752FBC498200A19C86 = {
+			isa = PBXGroup;
+			children = (
+				C47567802FBC498300A19C86 /* NZhelper */,
+				C475677F2FBC498300A19C86 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		C475677F2FBC498300A19C86 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				C475677E2FBC498300A19C86 /* NZhelper.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		C475677D2FBC498300A19C86 /* NZhelper */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C47567892FBC498400A19C86 /* Build configuration list for PBXNativeTarget "NZhelper" */;
+			buildPhases = (
+				C475677A2FBC498300A19C86 /* Sources */,
+				C475677B2FBC498300A19C86 /* Frameworks */,
+				C475677C2FBC498300A19C86 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				C47567802FBC498300A19C86 /* NZhelper */,
+			);
+			name = NZhelper;
+			packageProductDependencies = (
+			);
+			productName = NZhelper;
+			productReference = C475677E2FBC498300A19C86 /* NZhelper.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		C47567762FBC498300A19C86 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 2650;
+				LastUpgradeCheck = 2650;
+				TargetAttributes = {
+					C475677D2FBC498300A19C86 = {
+						CreatedOnToolsVersion = 26.5;
+					};
+				};
+			};
+			buildConfigurationList = C47567792FBC498300A19C86 /* Build configuration list for PBXProject "NZhelper" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = C47567752FBC498200A19C86;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = C475677F2FBC498300A19C86 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				C475677D2FBC498300A19C86 /* NZhelper */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		C475677C2FBC498300A19C86 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		C475677A2FBC498300A19C86 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		C47567872FBC498400A19C86 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.5;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		C47567882FBC498400A19C86 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.5;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		C475678A2FBC498400A19C86 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = Jerry.NZhelper;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		C475678B2FBC498400A19C86 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = Jerry.NZhelper;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		C47567792FBC498300A19C86 /* Build configuration list for PBXProject "NZhelper" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C47567872FBC498400A19C86 /* Debug */,
+				C47567882FBC498400A19C86 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C47567892FBC498400A19C86 /* Build configuration list for PBXNativeTarget "NZhelper" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C475678A2FBC498400A19C86 /* Debug */,
+				C475678B2FBC498400A19C86 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = C47567762FBC498300A19C86 /* Project object */;
+}

--- a/NZhelper.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/NZhelper.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/NZhelper.xcodeproj/xcuserdata/jerry.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/NZhelper.xcodeproj/xcuserdata/jerry.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>SchemeUserState</key>
+	<dict>
+		<key>NZhelper.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>0</integer>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/NZhelper/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/NZhelper/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/NZhelper/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/NZhelper/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/NZhelper/Assets.xcassets/Contents.json
+++ b/NZhelper/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/NZhelper/ContentView.swift
+++ b/NZhelper/ContentView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct ContentView: View {
+    @Environment(\.openURL) private var openURL
+
+    @State private var showUpdateAlert = false
+    @State private var updateURL: String = ""
+
+    var body: some View {
+        MainTabView()
+            .task {
+                if let release = await UpdateChecker.fetchLatestVersion() {
+                    if UpdateChecker.isNewer(release.version, than: UpdateChecker.currentVersion) {
+                        updateURL = release.url
+                        showUpdateAlert = true
+                    }
+                }
+            }
+            .alert("发现新版本", isPresented: $showUpdateAlert) {
+                Button("以后再说", role: .cancel) {}
+                Button("前往下载") {
+                    let fallbackURL = URL(string: "https://github.com/bug-bit/NzHelper/releases")!
+                    openURL(URL(string: updateURL) ?? fallbackURL)
+                }
+            } message: {
+                Text("GitHub 上有新版本可用，是否前往下载？")
+            }
+    }
+}

--- a/NZhelper/Models/Session.swift
+++ b/NZhelper/Models/Session.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+struct Session: Identifiable, Codable, Equatable {
+    var id: UUID = UUID()
+    var timestamp: Date
+    var duration: Int
+    var remark: String
+    var location: String
+    var watchedMovie: Bool
+    var climax: Bool
+    var rating: Float
+    var mood: String
+    var props: String
+
+    static var dateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone.current
+        return f
+    }()
+}
+
+extension JSONEncoder {
+    static var sessionEncoder: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .formatted(Session.dateFormatter)
+        encoder.outputFormatting = .prettyPrinted
+        return encoder
+    }
+}
+
+extension JSONDecoder {
+    static var sessionDecoder: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .formatted(Session.dateFormatter)
+        return decoder
+    }
+}

--- a/NZhelper/NZhelperApp.swift
+++ b/NZhelper/NZhelperApp.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+@main
+struct NZhelperApp: App {
+    @StateObject private var timerManager = TimerManager()
+    @StateObject private var repository = SessionRepository.shared
+
+    @Environment(\.scenePhase) private var scenePhase
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(timerManager)
+                .environmentObject(repository)
+                .onChange(of: scenePhase) { _, newPhase in
+                    switch newPhase {
+                    case .active:
+                        timerManager.handleEnterForeground()
+                        DailyReminderScheduler.shared.refresh(for: repository.sessions)
+                    case .background, .inactive:
+                        timerManager.handleEnterBackground()
+                    @unknown default:
+                        break
+                    }
+                }
+        }
+    }
+}

--- a/NZhelper/Services/DailyReminderScheduler.swift
+++ b/NZhelper/Services/DailyReminderScheduler.swift
@@ -1,0 +1,126 @@
+import Foundation
+import UserNotifications
+
+struct ReminderSettings {
+    static let enabledKey = "dailyReminderEnabled"
+    static let hourKey = "dailyReminderHour"
+    static let minuteKey = "dailyReminderMinute"
+
+    static let defaultHour = 21
+    static let defaultMinute = 0
+}
+
+final class DailyReminderScheduler {
+    static let shared = DailyReminderScheduler()
+
+    private let notificationIdentifierPrefix = "daily-no-session-reminder"
+    private let scheduleDays = 30
+    private let center = UNUserNotificationCenter.current()
+
+    private init() {}
+
+    func requestAuthorization() async -> Bool {
+        do {
+            return try await center.requestAuthorization(options: [.alert, .sound, .badge])
+        } catch {
+            print("Notification authorization failed: \(error)")
+            return false
+        }
+    }
+
+    func refresh(for sessions: [Session]) {
+        let defaults = UserDefaults.standard
+        guard defaults.bool(forKey: ReminderSettings.enabledKey) else {
+            cancel()
+            return
+        }
+
+        let hour = normalizedHour(defaults.object(forKey: ReminderSettings.hourKey) as? Int)
+        let minute = normalizedMinute(defaults.object(forKey: ReminderSettings.minuteKey) as? Int)
+
+        center.getNotificationSettings { [weak self] settings in
+            guard let self else { return }
+            guard settings.authorizationStatus == .authorized || settings.authorizationStatus == .provisional else {
+                self.cancel()
+                return
+            }
+
+            self.scheduleUpcomingReminders(hour: hour, minute: minute, sessions: sessions)
+        }
+    }
+
+    func cancel() {
+        center.getPendingNotificationRequests { [weak self] requests in
+            guard let self else { return }
+            let identifiers = requests
+                .map(\.identifier)
+                .filter { $0.hasPrefix(self.notificationIdentifierPrefix) }
+            self.center.removePendingNotificationRequests(withIdentifiers: identifiers)
+        }
+    }
+
+    private func scheduleUpcomingReminders(hour: Int, minute: Int, sessions: [Session]) {
+        cancel()
+
+        let calendar = Calendar.current
+        let now = Date()
+
+        for dayOffset in 0..<scheduleDays {
+            guard let day = calendar.date(byAdding: .day, value: dayOffset, to: now),
+                  let reminderDate = reminderDate(on: day, hour: hour, minute: minute, calendar: calendar),
+                  reminderDate > now
+            else { continue }
+
+            let hasRecord = sessions.contains { calendar.isDate($0.timestamp, inSameDayAs: reminderDate) }
+            guard !hasRecord else { continue }
+
+            let components = calendar.dateComponents([.year, .month, .day, .hour, .minute], from: reminderDate)
+            let trigger = UNCalendarNotificationTrigger(dateMatching: components, repeats: false)
+            let content = UNMutableNotificationContent()
+            content.title = "今天要起飞吗？"
+            content.body = "今天还没有记录，点开看看要不要记一下。"
+            content.sound = .default
+
+            let request = UNNotificationRequest(
+                identifier: notificationIdentifier(for: reminderDate, calendar: calendar),
+                content: content,
+                trigger: trigger
+            )
+
+            center.add(request) { error in
+                if let error {
+                    print("Failed to schedule daily reminder: \(error)")
+                }
+            }
+        }
+    }
+
+    private func reminderDate(on date: Date, hour: Int, minute: Int, calendar: Calendar) -> Date? {
+        var components = calendar.dateComponents([.year, .month, .day], from: date)
+        components.hour = hour
+        components.minute = minute
+        return calendar.date(from: components)
+    }
+
+    private func normalizedHour(_ hour: Int?) -> Int {
+        guard let hour, (0...23).contains(hour) else {
+            return ReminderSettings.defaultHour
+        }
+        return hour
+    }
+
+    private func normalizedMinute(_ minute: Int?) -> Int {
+        guard let minute, (0...59).contains(minute) else {
+            return ReminderSettings.defaultMinute
+        }
+        return minute
+    }
+
+    private func notificationIdentifier(for date: Date, calendar: Calendar) -> String {
+        let components = calendar.dateComponents([.year, .month, .day], from: date)
+        let year = components.year ?? 0
+        let month = components.month ?? 0
+        let day = components.day ?? 0
+        return "\(notificationIdentifierPrefix)-\(year)-\(month)-\(day)"
+    }
+}

--- a/NZhelper/Services/SessionRepository.swift
+++ b/NZhelper/Services/SessionRepository.swift
@@ -1,0 +1,126 @@
+import Combine
+import Foundation
+
+class SessionRepository: ObservableObject {
+    static let shared = SessionRepository()
+
+    @Published var sessions: [Session] = []
+
+    private let fileURL: URL
+
+    private init() {
+        let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        fileURL = docs.appendingPathComponent("sessions.json")
+        loadSessions()
+    }
+
+    func loadSessions() {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            sessions = []
+            DailyReminderScheduler.shared.refresh(for: sessions)
+            return
+        }
+        do {
+            let data = try Data(contentsOf: fileURL)
+            sessions = try JSONDecoder.sessionDecoder.decode([Session].self, from: data)
+        } catch {
+            sessions = []
+            print("Failed to load sessions: \(error)")
+        }
+        DailyReminderScheduler.shared.refresh(for: sessions)
+    }
+
+    func saveSessions() {
+        do {
+            let data = try JSONEncoder.sessionEncoder.encode(sessions)
+            try data.write(to: fileURL, options: .atomic)
+            DailyReminderScheduler.shared.refresh(for: sessions)
+        } catch {
+            print("Failed to save sessions: \(error)")
+        }
+    }
+
+    func addSession(_ session: Session) {
+        sessions.append(session)
+        saveSessions()
+    }
+
+    func updateSession(_ session: Session) {
+        if let index = sessions.firstIndex(where: { $0.id == session.id }) {
+            sessions[index] = session
+            saveSessions()
+        }
+    }
+
+    func deleteSession(_ session: Session) {
+        sessions.removeAll { $0.id == session.id }
+        saveSessions()
+    }
+
+    func deleteAllSessions() {
+        sessions.removeAll()
+        saveSessions()
+    }
+
+    func exportSessions() -> URL? {
+        do {
+            let data = try JSONEncoder.sessionEncoder.encode(sessions)
+            let temp = FileManager.default.temporaryDirectory
+                .appendingPathComponent("NzHelper_export_\(Date().timeIntervalSince1970).json")
+            try data.write(to: temp)
+            return temp
+        } catch {
+            print("Export failed: \(error)")
+            return nil
+        }
+    }
+
+    func importSessions(from url: URL) -> Bool {
+        let gotAccess = url.startAccessingSecurityScopedResource()
+        defer { if gotAccess { url.stopAccessingSecurityScopedResource() } }
+
+        do {
+            let data = try Data(contentsOf: url)
+            if let imported = try? JSONDecoder.sessionDecoder.decode([Session].self, from: data) {
+                sessions.append(contentsOf: imported)
+                saveSessions()
+                return true
+            }
+            if let json = try? JSONSerialization.jsonObject(with: data) as? [[Any]] {
+                var imported: [Session] = []
+                for item in json {
+                    guard item.count >= 9,
+                          let ts = item[0] as? String,
+                          let date = Session.dateFormatter.date(from: ts),
+                          let duration = item[1] as? Int,
+                          let remark = item[2] as? String,
+                          let location = item[3] as? String,
+                          let movie = item[4] as? Bool,
+                          let climax = item[5] as? Bool,
+                          let rating = item[6] as? Double,
+                          let mood = item[7] as? String,
+                          let props = item[8] as? String
+                    else { continue }
+                    imported.append(Session(
+                        timestamp: date,
+                        duration: duration,
+                        remark: remark,
+                        location: location,
+                        watchedMovie: movie,
+                        climax: climax,
+                        rating: Float(rating),
+                        mood: mood,
+                        props: props
+                    ))
+                }
+                sessions.append(contentsOf: imported)
+                saveSessions()
+                return true
+            }
+            return false
+        } catch {
+            print("Import failed: \(error)")
+            return false
+        }
+    }
+}

--- a/NZhelper/Services/TimerManager.swift
+++ b/NZhelper/Services/TimerManager.swift
@@ -1,0 +1,85 @@
+import Foundation
+import Combine
+
+class TimerManager: ObservableObject {
+    @Published var elapsedTime: TimeInterval = 0
+    @Published var isRunning = false
+    @Published var isPaused = false
+
+    private var startDate: Date?
+    private var accumulatedTime: TimeInterval = 0
+    private var timer: Timer?
+
+    var totalElapsedSeconds: Int {
+        if let start = startDate {
+            return Int(accumulatedTime + Date().timeIntervalSince(start))
+        }
+        return Int(accumulatedTime)
+    }
+
+    func start() {
+        if isPaused {
+            startDate = Date()
+            isPaused = false
+        } else {
+            accumulatedTime = 0
+            startDate = Date()
+        }
+        isRunning = true
+        startTick()
+    }
+
+    func pause() {
+        guard let start = startDate else { return }
+        accumulatedTime += Date().timeIntervalSince(start)
+        startDate = nil
+        isPaused = true
+        stopTick()
+    }
+
+    func stop() {
+        if let start = startDate {
+            accumulatedTime += Date().timeIntervalSince(start)
+        }
+        startDate = nil
+        isRunning = false
+        isPaused = false
+        stopTick()
+        elapsedTime = accumulatedTime
+    }
+
+    func reset() {
+        stopTick()
+        accumulatedTime = 0
+        elapsedTime = 0
+        isRunning = false
+        isPaused = false
+        startDate = nil
+    }
+
+    func handleEnterBackground() {
+        guard isRunning, !isPaused, let start = startDate else { return }
+        accumulatedTime += Date().timeIntervalSince(start)
+        startDate = nil
+        stopTick()
+    }
+
+    func handleEnterForeground() {
+        guard isRunning, !isPaused else { return }
+        startDate = Date()
+        startTick()
+    }
+
+    private func startTick() {
+        stopTick()
+        timer = Timer.scheduledTimer(withTimeInterval: 0.05, repeats: true) { [weak self] _ in
+            guard let self, let start = self.startDate else { return }
+            self.elapsedTime = self.accumulatedTime + Date().timeIntervalSince(start)
+        }
+    }
+
+    private func stopTick() {
+        timer?.invalidate()
+        timer = nil
+    }
+}

--- a/NZhelper/Services/UpdateChecker.swift
+++ b/NZhelper/Services/UpdateChecker.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+struct UpdateChecker {
+    static let repoOwner = "bug-bit"
+    static let repoName = "NzHelper"
+
+    static func fetchLatestVersion() async -> (version: String, url: String)? {
+        let url = URL(string: "https://api.github.com/repos/\(repoOwner)/\(repoName)/releases/latest")!
+        var request = URLRequest(url: url)
+        request.setValue("NzHelper-iOS/1.0", forHTTPHeaderField: "User-Agent")
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard (response as? HTTPURLResponse)?.statusCode == 200 else { return nil }
+
+            struct Release: Codable {
+                let tag_name: String
+                let name: String
+                let html_url: String
+            }
+            let release = try JSONDecoder().decode(Release.self, from: data)
+            return (release.tag_name, release.html_url)
+        } catch {
+            print("Update check failed: \(error)")
+            return nil
+        }
+    }
+
+    static var currentVersion: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
+    }
+
+    static func isNewer(_ remote: String, than local: String) -> Bool {
+        let remoteParts = remote
+            .trimmingCharacters(in: CharacterSet(charactersIn: "v"))
+            .split(separator: ".")
+            .compactMap { Int($0) }
+        let localParts = local
+            .split(separator: ".")
+            .compactMap { Int($0) }
+        let maxLen = max(remoteParts.count, localParts.count)
+        for i in 0..<maxLen {
+            let r = i < remoteParts.count ? remoteParts[i] : 0
+            let l = i < localParts.count ? localParts[i] : 0
+            if r > l { return true }
+            if r < l { return false }
+        }
+        return false
+    }
+}

--- a/NZhelper/Views/AboutView.swift
+++ b/NZhelper/Views/AboutView.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+struct AboutView: View {
+    var body: some View {
+        List {
+            Section {
+                HStack {
+                    Spacer()
+                    VStack(spacing: 12) {
+                        Image(systemName: "chart.bar.doc.horizontal.fill")
+                            .font(.system(size: 56))
+                            .foregroundStyle(.blue)
+                        Text("牛子小助手")
+                            .font(.title2)
+                            .bold()
+                        Text("v\(version)")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                }
+                .padding(.vertical, 16)
+                .listRowBackground(Color.clear)
+            }
+
+            Section {
+                Link(destination: URL(string: "https://github.com/bug-bit/NzHelper")!) {
+                    HStack {
+                        Label("GitHub 仓库", systemImage: "link")
+                        Spacer()
+                        Image(systemName: "arrow.up.right")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+
+            Section {
+                NavigationLink {
+                    OpenSourceView()
+                } label: {
+                    Label("开源许可", systemImage: "doc.text")
+                }
+            }
+        }
+        .navigationTitle("关于")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    var version: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
+    }
+}

--- a/NZhelper/Views/Components/DetailsFormView.swift
+++ b/NZhelper/Views/Components/DetailsFormView.swift
@@ -1,0 +1,136 @@
+import SwiftUI
+
+struct DetailsFormView: View {
+    let duration: Int
+    var editingSession: Session? = nil
+    let onSave: (Session) -> Void
+    let onCancel: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var location = ""
+    @State private var watchedMovie = false
+    @State private var climax = true
+    @State private var selectedProp = "手"
+    @State private var rating: Float = 3.0
+    @State private var selectedMood = "平静"
+    @State private var remark = ""
+
+    private let props = ["手", "斐济杯", "小胶妻"]
+    private let moods = ["平静", "愉悦", "兴奋", "疲惫", "这是最后一次！"]
+
+    init(duration: Int, editingSession: Session? = nil, onSave: @escaping (Session) -> Void, onCancel: @escaping () -> Void) {
+        self.duration = duration
+        self.editingSession = editingSession
+        self.onSave = onSave
+        self.onCancel = onCancel
+        if let s = editingSession {
+            _location = State(initialValue: s.location)
+            _watchedMovie = State(initialValue: s.watchedMovie)
+            _climax = State(initialValue: s.climax)
+            _selectedProp = State(initialValue: s.props)
+            _rating = State(initialValue: s.rating)
+            _selectedMood = State(initialValue: s.mood)
+            _remark = State(initialValue: s.remark)
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    HStack {
+                        Text("时长")
+                        Spacer()
+                        Text(formatDuration(duration))
+                            .foregroundStyle(.secondary)
+                    }
+                    TextField("地点", text: $location)
+                }
+
+                Section {
+                    Toggle("观看成人内容", isOn: $watchedMovie)
+                    Toggle("高潮", isOn: $climax)
+                }
+
+                Section("道具") {
+                    Picker("道具", selection: $selectedProp) {
+                        ForEach(props, id: \.self) { p in
+                            Text(p).tag(p)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                }
+
+                Section("评分") {
+                    VStack(spacing: 8) {
+                        Slider(value: Binding<Double>(
+                            get: { Double(rating) },
+                            set: { rating = Float(($0 * 2).rounded() / 2) }
+                        ), in: 0...5, step: 0.5)
+                        HStack {
+                            Text("0.0").font(.caption).foregroundStyle(.secondary)
+                            Spacer()
+                            Text(String(format: "%.1f", rating)).font(.title3).bold()
+                            Spacer()
+                            Text("5.0").font(.caption).foregroundStyle(.secondary)
+                        }
+                    }
+                }
+
+                Section("心情") {
+                    Picker("心情", selection: $selectedMood) {
+                        ForEach(moods, id: \.self) { m in
+                            Text(m).tag(m)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                }
+
+                Section("备注") {
+                    TextField("备注", text: $remark, axis: .vertical)
+                        .lineLimit(3...6)
+                }
+            }
+            .navigationTitle(editingSession != nil ? "编辑记录" : "记录详情")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("取消") {
+                        onCancel()
+                        dismiss()
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("保存") {
+                        let session = Session(
+                            id: editingSession?.id ?? UUID(),
+                            timestamp: editingSession?.timestamp ?? Date(),
+                            duration: duration,
+                            remark: remark,
+                            location: location,
+                            watchedMovie: watchedMovie,
+                            climax: climax,
+                            rating: rating,
+                            mood: selectedMood,
+                            props: selectedProp
+                        )
+                        onSave(session)
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+
+    func formatDuration(_ seconds: Int) -> String {
+        let h = seconds / 3600
+        let m = (seconds % 3600) / 60
+        let s = seconds % 60
+        var parts: [String] = []
+        if h > 0 { parts.append("\(h)小时") }
+        if m > 0 { parts.append("\(m)分") }
+        parts.append("\(s)秒")
+        return parts.joined()
+    }
+}

--- a/NZhelper/Views/HistoryView.swift
+++ b/NZhelper/Views/HistoryView.swift
@@ -1,0 +1,241 @@
+import SwiftUI
+import UIKit
+import UniformTypeIdentifiers
+
+struct HistoryView: View {
+    @EnvironmentObject var repository: SessionRepository
+
+    @State private var detailSession: Session?
+    @State private var editSession: Session?
+    @State private var sessionToDelete: Session?
+    @State private var showDeleteConfirm = false
+    @State private var showClearConfirm = false
+    @State private var showImportPicker = false
+    @State private var importResult: (success: Bool, message: String)?
+    @State private var showImportAlert = false
+    @State private var exportURL: URL?
+    @State private var showShareSheet = false
+
+    var body: some View {
+        Group {
+            if repository.sessions.isEmpty {
+                ContentUnavailableView(
+                    "暂无记录",
+                    systemImage: "clock.arrow.circlepath",
+                    description: Text("开始计时以创建第一条记录")
+                )
+            } else {
+                List {
+                    ForEach(repository.sessions.reversed()) { session in
+                        SessionRowView(session: session)
+                            .contentShape(Rectangle())
+                            .onTapGesture {
+                                detailSession = session
+                            }
+                            .swipeActions(edge: .trailing) {
+                                Button(role: .destructive) {
+                                    sessionToDelete = session
+                                    showDeleteConfirm = true
+                                } label: {
+                                    Label("删除", systemImage: "trash")
+                                }
+
+                                Button {
+                                    editSession = session
+                                } label: {
+                                    Label("编辑", systemImage: "pencil")
+                                }
+                                .tint(.orange)
+                            }
+                    }
+                }
+            }
+        }
+        .navigationTitle("历史")
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                if !repository.sessions.isEmpty {
+                    Menu {
+                        Button {
+                            showImportPicker = true
+                        } label: {
+                            Label("导入", systemImage: "square.and.arrow.down")
+                        }
+                        Button {
+                            exportURL = repository.exportSessions()
+                            showShareSheet = exportURL != nil
+                        } label: {
+                            Label("导出", systemImage: "square.and.arrow.up")
+                        }
+                        Divider()
+                        Button(role: .destructive) {
+                            showClearConfirm = true
+                        } label: {
+                            Label("清空全部", systemImage: "trash")
+                        }
+                    } label: {
+                        Image(systemName: "ellipsis.circle")
+                    }
+                }
+            }
+        }
+        .sheet(item: $detailSession) { session in
+            SessionDetailView(session: session)
+        }
+        .sheet(item: $editSession) { session in
+            DetailsFormView(
+                duration: session.duration,
+                editingSession: session,
+                onSave: { updated in
+                    repository.updateSession(updated)
+                },
+                onCancel: {}
+            )
+        }
+        .alert("确认删除", isPresented: $showDeleteConfirm) {
+            Button("取消", role: .cancel) {}
+            Button("删除", role: .destructive) {
+                if let s = sessionToDelete {
+                    repository.deleteSession(s)
+                }
+            }
+        } message: {
+            Text("此操作无法撤销")
+        }
+        .alert("确认清空", isPresented: $showClearConfirm) {
+            Button("取消", role: .cancel) {}
+            Button("清空", role: .destructive) {
+                repository.deleteAllSessions()
+            }
+        } message: {
+            Text("将删除所有历史记录，此操作无法撤销")
+        }
+        .fileImporter(isPresented: $showImportPicker, allowedContentTypes: [.json]) { result in
+            switch result {
+            case .success(let url):
+                let ok = repository.importSessions(from: url)
+                importResult = (ok, ok ? "导入成功" : "导入失败，文件格式不正确")
+            case .failure:
+                importResult = (false, "导入失败")
+            }
+            showImportAlert = true
+        }
+        .alert(importResult?.message ?? "", isPresented: $showImportAlert) {
+            Button("确定", role: .cancel) {}
+        }
+        .sheet(isPresented: $showShareSheet) {
+            if let url = exportURL {
+                ShareSheet(items: [url])
+            }
+        }
+    }
+}
+
+struct SessionRowView: View {
+    let session: Session
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(formatDate(session.timestamp))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text(formatDuration(session.duration))
+                    .font(.subheadline)
+                    .bold()
+                    .monospacedDigit()
+            }
+            if !session.remark.isEmpty {
+                Text(session.remark)
+                    .font(.body)
+                    .lineLimit(2)
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    func formatDate(_ date: Date) -> String {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd HH:mm"
+        return f.string(from: date)
+    }
+
+    func formatDuration(_ seconds: Int) -> String {
+        let h = seconds / 3600
+        let m = (seconds % 3600) / 60
+        let s = seconds % 60
+        if h > 0 {
+            return String(format: "%d:%02d:%02d", h, m, s)
+        }
+        return String(format: "%02d:%02d", m, s)
+    }
+}
+
+struct SessionDetailView: View {
+    let session: Session
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("基本信息") {
+                    LabeledContent("时间", value: formatDateTime(session.timestamp))
+                    LabeledContent("时长", value: formatDuration(session.duration))
+                    LabeledContent("地点", value: session.location.isEmpty ? "未填写" : session.location)
+                }
+                Section {
+                    LabeledContent("观看成人内容", value: session.watchedMovie ? "是" : "否")
+                    LabeledContent("高潮", value: session.climax ? "是" : "否")
+                }
+                Section {
+                    LabeledContent("道具", value: session.props)
+                    LabeledContent("评分", value: String(format: "%.1f", session.rating))
+                    LabeledContent("心情", value: session.mood)
+                }
+                if !session.remark.isEmpty {
+                    Section("备注") {
+                        Text(session.remark)
+                    }
+                }
+            }
+            .navigationTitle("记录详情")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("关闭") { dismiss() }
+                }
+            }
+        }
+    }
+
+    func formatDateTime(_ date: Date) -> String {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return f.string(from: date)
+    }
+
+    func formatDuration(_ seconds: Int) -> String {
+        let h = seconds / 3600
+        let m = (seconds % 3600) / 60
+        let s = seconds % 60
+        if h > 0 {
+            return String(format: "%d小时%d分%d秒", h, m, s)
+        }
+        if m > 0 {
+            return String(format: "%d分%d秒", m, s)
+        }
+        return "\(s)秒"
+    }
+}
+
+struct ShareSheet: UIViewControllerRepresentable {
+    let items: [Any]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: items, applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+}

--- a/NZhelper/Views/HomeView.swift
+++ b/NZhelper/Views/HomeView.swift
@@ -1,0 +1,99 @@
+import SwiftUI
+
+struct HomeView: View {
+    @EnvironmentObject var timerManager: TimerManager
+    @EnvironmentObject var repository: SessionRepository
+    @State private var showEndConfirm = false
+    @State private var showDetails = false
+
+    var body: some View {
+        VStack(spacing: 44) {
+            Spacer()
+
+            Text(formatElapsed(timerManager.elapsedTime))
+                .font(.system(size: 56, weight: .light, design: .monospaced))
+                .monospacedDigit()
+                .contentTransition(.numericText())
+
+            HStack(spacing: 20) {
+                if !timerManager.isRunning {
+                    Button {
+                        timerManager.start()
+                    } label: {
+                        Label("开始", systemImage: "play.fill")
+                            .frame(minWidth: 72)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
+                } else {
+                    if !timerManager.isPaused {
+                        Button {
+                            timerManager.pause()
+                        } label: {
+                            Label("暂停", systemImage: "pause.fill")
+                                .frame(minWidth: 72)
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.large)
+                    } else {
+                        Button {
+                            timerManager.start()
+                        } label: {
+                            Label("继续", systemImage: "play.fill")
+                                .frame(minWidth: 72)
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.large)
+                    }
+
+                    Button {
+                        if timerManager.totalElapsedSeconds > 0 {
+                            showEndConfirm = true
+                        } else {
+                            timerManager.reset()
+                        }
+                    } label: {
+                        Label("结束", systemImage: "stop.fill")
+                            .frame(minWidth: 72)
+                    }
+                    .buttonStyle(.bordered)
+                    .tint(.red)
+                    .controlSize(.large)
+                }
+            }
+
+            Spacer()
+        }
+        .navigationTitle("计时")
+        .alert("结束了吗？", isPresented: $showEndConfirm) {
+            Button("再坚持一下", role: .cancel) {}
+            Button("燃尽了") {
+                timerManager.stop()
+                showDetails = true
+            }
+        }
+        .sheet(isPresented: $showDetails) {
+            DetailsFormView(
+                duration: timerManager.totalElapsedSeconds,
+                onSave: { session in
+                    repository.addSession(session)
+                    timerManager.reset()
+                },
+                onCancel: {
+                    timerManager.reset()
+                }
+            )
+        }
+    }
+
+    func formatElapsed(_ interval: TimeInterval) -> String {
+        let total = Int(interval)
+        let h = total / 3600
+        let m = (total % 3600) / 60
+        let s = total % 60
+        if h > 0 {
+            return String(format: "%02d:%02d:%02d", h, m, s)
+        }
+        return String(format: "%02d:%02d", m, s)
+    }
+}

--- a/NZhelper/Views/MainTabView.swift
+++ b/NZhelper/Views/MainTabView.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+struct MainTabView: View {
+    @State private var selectedTab = 0
+
+    var body: some View {
+        TabView(selection: $selectedTab) {
+            NavigationStack {
+                HomeView()
+            }
+            .tabItem {
+                Label("计时", systemImage: "stopwatch")
+            }
+            .tag(0)
+
+            NavigationStack {
+                StatisticsView()
+            }
+            .tabItem {
+                Label("统计", systemImage: "chart.bar.fill")
+            }
+            .tag(1)
+
+            NavigationStack {
+                HistoryView()
+            }
+            .tabItem {
+                Label("历史", systemImage: "clock.arrow.circlepath")
+            }
+            .tag(2)
+
+            NavigationStack {
+                SettingsView()
+            }
+            .tabItem {
+                Label("设置", systemImage: "gearshape.fill")
+            }
+            .tag(3)
+        }
+    }
+}

--- a/NZhelper/Views/OpenSourceView.swift
+++ b/NZhelper/Views/OpenSourceView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct LicenseItem: Identifiable {
+    let id = UUID()
+    let name: String
+    let author: String
+    let url: String
+    let license: String
+}
+
+struct OpenSourceView: View {
+    let licenses: [LicenseItem] = [
+        LicenseItem(name: "SwiftUI", author: "Apple Inc.", url: "https://developer.apple.com/xcode/swiftui/", license: "Proprietary"),
+        LicenseItem(name: "Swift Charts", author: "Apple Inc.", url: "https://developer.apple.com/documentation/charts", license: "Proprietary"),
+        LicenseItem(name: "Foundation", author: "Apple Inc.", url: "https://developer.apple.com/documentation/foundation", license: "Proprietary"),
+        LicenseItem(name: "Combine", author: "Apple Inc.", url: "https://developer.apple.com/documentation/combine", license: "Proprietary"),
+        LicenseItem(name: "UniformTypeIdentifiers", author: "Apple Inc.", url: "https://developer.apple.com/documentation/uniformtypeidentifiers", license: "Proprietary"),
+    ]
+
+    var body: some View {
+        List(licenses) { item in
+            VStack(alignment: .leading, spacing: 4) {
+                Text(item.name).font(.body).bold()
+                Text(item.author).font(.caption).foregroundStyle(.secondary)
+                HStack {
+                    if let url = URL(string: item.url) {
+                        Link(destination: url) {
+                            Text(item.url)
+                                .font(.caption2)
+                                .foregroundStyle(.blue)
+                                .lineLimit(1)
+                        }
+                    }
+                    Spacer()
+                    Text(item.license)
+                        .font(.caption2)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(.quaternary, in: RoundedRectangle(cornerRadius: 4))
+                }
+            }
+            .padding(.vertical, 2)
+        }
+        .navigationTitle("开源许可")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/NZhelper/Views/SettingsView.swift
+++ b/NZhelper/Views/SettingsView.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @EnvironmentObject private var repository: SessionRepository
+
+    @AppStorage(ReminderSettings.enabledKey) private var reminderEnabled = false
+    @AppStorage(ReminderSettings.hourKey) private var reminderHour = ReminderSettings.defaultHour
+    @AppStorage(ReminderSettings.minuteKey) private var reminderMinute = ReminderSettings.defaultMinute
+
+    @State private var showPermissionAlert = false
+
+    var body: some View {
+        List {
+            Section {
+                Toggle("今天没有记录时提醒", isOn: reminderBinding)
+
+                DatePicker(
+                    "提醒时间",
+                    selection: reminderTimeBinding,
+                    displayedComponents: .hourAndMinute
+                )
+                .disabled(!reminderEnabled)
+            } header: {
+                Text("每日提醒")
+            } footer: {
+                Text("到设定时间时，如果当天还没有记录，会发送「今天要起飞吗？」通知。")
+            }
+
+            NavigationLink {
+                AboutView()
+            } label: {
+                Label("关于", systemImage: "info.circle")
+            }
+        }
+        .navigationTitle("设置")
+        .alert("通知未开启", isPresented: $showPermissionAlert) {
+            Button("知道了", role: .cancel) {}
+        } message: {
+            Text("请在系统设置中允许通知后再开启每日提醒。")
+        }
+        .onAppear {
+            DailyReminderScheduler.shared.refresh(for: repository.sessions)
+        }
+        .onChange(of: reminderHour) { _, _ in
+            DailyReminderScheduler.shared.refresh(for: repository.sessions)
+        }
+        .onChange(of: reminderMinute) { _, _ in
+            DailyReminderScheduler.shared.refresh(for: repository.sessions)
+        }
+    }
+
+    private var reminderBinding: Binding<Bool> {
+        Binding {
+            reminderEnabled
+        } set: { newValue in
+            if newValue {
+                Task {
+                    let granted = await DailyReminderScheduler.shared.requestAuthorization()
+                    await MainActor.run {
+                        reminderEnabled = granted
+                        showPermissionAlert = !granted
+                        DailyReminderScheduler.shared.refresh(for: repository.sessions)
+                    }
+                }
+            } else {
+                reminderEnabled = false
+                DailyReminderScheduler.shared.cancel()
+            }
+        }
+    }
+
+    private var reminderTimeBinding: Binding<Date> {
+        Binding {
+            var components = DateComponents()
+            components.hour = reminderHour
+            components.minute = reminderMinute
+            return Calendar.current.date(from: components) ?? Date()
+        } set: { newValue in
+            let components = Calendar.current.dateComponents([.hour, .minute], from: newValue)
+            reminderHour = components.hour ?? ReminderSettings.defaultHour
+            reminderMinute = components.minute ?? ReminderSettings.defaultMinute
+        }
+    }
+}

--- a/NZhelper/Views/StatisticsView.swift
+++ b/NZhelper/Views/StatisticsView.swift
@@ -1,0 +1,352 @@
+import SwiftUI
+import Charts
+
+enum ChartPeriod: String, CaseIterable {
+    case week = "周"
+    case month = "月"
+    case year = "年"
+}
+
+struct StatisticsView: View {
+    @EnvironmentObject var repository: SessionRepository
+    @State private var selectedPeriod: ChartPeriod = .week
+
+    var body: some View {
+        Group {
+            if repository.sessions.isEmpty {
+                ContentUnavailableView(
+                    "暂无统计",
+                    systemImage: "chart.bar.fill",
+                    description: Text("(。・ω・。)")
+                )
+            } else {
+                ScrollView {
+                    VStack(spacing: 16) {
+                        latestSessionCard
+                        overallStatsCard
+                        chartCard
+                        Spacer(minLength: 20)
+                    }
+                    .padding()
+                }
+            }
+        }
+        .navigationTitle("统计")
+        .navigationBarTitleDisplayMode(.large)
+    }
+
+    var latestSessionCard: some View {
+        let sorted = repository.sessions.sorted { $0.timestamp > $1.timestamp }
+        guard let latest = sorted.first else { return AnyView(EmptyView()) }
+        let daysAgo = Calendar.current.dateComponents([.day], from: latest.timestamp, to: Date()).day ?? 0
+        let messages = latestStatusMessage(daysAgo: daysAgo)
+
+        return AnyView(GroupBox {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Image(systemName: "clock.badge.checkmark")
+                        .font(.title2)
+                        .foregroundStyle(.blue)
+                    Text("最近一次记录")
+                        .font(.headline)
+                }
+                Divider()
+                HStack {
+                    Text("时间").foregroundStyle(.secondary)
+                    Spacer()
+                    Text(formatDateTime(latest.timestamp)).font(.subheadline)
+                }
+                HStack {
+                    Text("持续").foregroundStyle(.secondary)
+                    Spacer()
+                    Text(formatDuration(latest.duration)).bold().font(.subheadline)
+                }
+                Divider()
+                Text(messages.status)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                Text(messages.motivation)
+                    .font(.callout)
+            }
+        } label: {
+            Label("概况", systemImage: "person.fill")
+        })
+    }
+
+    var overallStatsCard: some View {
+        let sessions = repository.sessions
+        let totalDuration = sessions.reduce(0) { $0 + $1.duration }
+        let avgDuration = sessions.isEmpty ? 0 : totalDuration / sessions.count
+        let calendar = Calendar.current
+        let now = Date()
+        let weekAgo = calendar.date(byAdding: .day, value: -7, to: now)!
+        let monthAgo = calendar.date(byAdding: .month, value: -1, to: now)!
+        let yearAgo = calendar.date(byAdding: .year, value: -1, to: now)!
+        let weekCount = sessions.filter { $0.timestamp >= weekAgo }.count
+        let monthCount = sessions.filter { $0.timestamp >= monthAgo }.count
+        let yearCount = sessions.filter { $0.timestamp >= yearAgo }.count
+        let count = sessions.count
+        let countMessages = [
+            "千里之行，始于足下",
+            "坚持就是胜利",
+            "你已经超越了99%的人",
+            "你已成为大师",
+            "数据量惊人，值得骄傲",
+            "你是真正的记录之王"
+        ]
+        let msg = countMessages[min(count / 10, countMessages.count - 1)]
+
+        return GroupBox {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Image(systemName: "chart.bar.doc.horizontal")
+                        .font(.title2)
+                        .foregroundStyle(.green)
+                    Text("总体统计").font(.headline)
+                }
+                Divider()
+                StatRow(label: "总时长", value: formatDuration(totalDuration))
+                StatRow(label: "平均时长", value: formatDuration(avgDuration))
+                StatRow(label: "总次数", value: "\(count) 次")
+                StatRow(label: "本周", value: "\(weekCount) 次")
+                StatRow(label: "本月", value: "\(monthCount) 次")
+                StatRow(label: "本年", value: "\(yearCount) 次")
+                Divider()
+                Text(msg).font(.callout).foregroundStyle(.secondary)
+            }
+        } label: {
+            Label("数据", systemImage: "chart.bar.fill")
+        }
+    }
+
+    var chartCard: some View {
+        GroupBox {
+            VStack(alignment: .leading, spacing: 12) {
+                Picker("周期", selection: $selectedPeriod) {
+                    ForEach(ChartPeriod.allCases, id: \.self) { p in
+                        Text(p.rawValue).tag(p)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                switch selectedPeriod {
+                case .week:
+                    weekChartView
+                case .month:
+                    monthChartView
+                case .year:
+                    yearChartView
+                }
+            }
+        } label: {
+            Label("趋势", systemImage: "chart.xyaxis.line")
+        }
+    }
+
+    var weekChartView: some View {
+        let data = dailyData(days: 7)
+        if data.allSatisfy({ $0.minutes == 0 }) {
+            return AnyView(
+                Text("本周暂无记录").foregroundStyle(.secondary).padding()
+            )
+        }
+        return AnyView(
+            Chart {
+                ForEach(data, id: \.date) { item in
+                    BarMark(
+                        x: .value("日期", item.date, unit: .day),
+                        y: .value("分钟", item.minutes)
+                    )
+                    .foregroundStyle(.blue.gradient)
+                }
+            }
+            .chartXAxis {
+                AxisMarks(values: .stride(by: .day)) { value in
+                    AxisValueLabel(format: .dateTime.weekday(.abbreviated))
+                }
+            }
+            .chartYAxis {
+                AxisMarks {
+                    AxisValueLabel()
+                    AxisGridLine()
+                }
+            }
+            .frame(height: 160)
+        )
+    }
+
+    var monthChartView: some View {
+        let data = monthDailyData()
+        if data.allSatisfy({ $0.minutes == 0 }) {
+            return AnyView(
+                Text("本月暂无记录").foregroundStyle(.secondary).padding()
+            )
+        }
+        return AnyView(
+            Chart {
+                ForEach(data, id: \.date) { item in
+                    BarMark(
+                        x: .value("日期", item.date, unit: .day),
+                        y: .value("分钟", item.minutes)
+                    )
+                    .foregroundStyle(.orange.gradient)
+                }
+            }
+            .chartXAxis {
+                AxisMarks(values: .stride(by: .day, count: 5)) { value in
+                    AxisValueLabel(format: .dateTime.day())
+                }
+            }
+            .chartYAxis {
+                AxisMarks {
+                    AxisValueLabel()
+                    AxisGridLine()
+                }
+            }
+            .frame(height: 160)
+        )
+    }
+
+    var yearChartView: some View {
+        let data = yearMonthlyData()
+        if data.allSatisfy({ $0.count == 0 }) {
+            return AnyView(
+                Text("今年暂无记录").foregroundStyle(.secondary).padding()
+            )
+        }
+        return AnyView(
+            Chart {
+                ForEach(data, id: \.month) { item in
+                    BarMark(
+                        x: .value("月份", item.month),
+                        y: .value("次数", item.count)
+                    )
+                    .foregroundStyle(.purple.gradient)
+                }
+            }
+            .chartXAxis {
+                AxisMarks(values: .automatic) { value in
+                    if let month = value.as(Int.self), month >= 1, month <= 12 {
+                        AxisValueLabel("\(month)月")
+                    }
+                }
+            }
+            .chartYAxis {
+                AxisMarks {
+                    AxisValueLabel()
+                    AxisGridLine()
+                }
+            }
+            .frame(height: 160)
+        )
+    }
+
+    struct DailyStat {
+        let date: Date
+        let minutes: Double
+    }
+
+    struct MonthlyStat {
+        let month: Int
+        let count: Int
+        let minutes: Double
+    }
+
+    func dailyData(days: Int) -> [DailyStat] {
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+        var result: [DailyStat] = []
+        for i in 0..<days {
+            let day = calendar.date(byAdding: .day, value: -(days - 1 - i), to: today)!
+            let dayEnd = calendar.date(byAdding: .day, value: 1, to: day)!
+            let seconds = repository.sessions
+                .filter { $0.timestamp >= day && $0.timestamp < dayEnd }
+                .reduce(0) { $0 + $1.duration }
+            result.append(DailyStat(date: day, minutes: Double(seconds) / 60.0))
+        }
+        return result
+    }
+
+    func monthDailyData() -> [DailyStat] {
+        let calendar = Calendar.current
+        let now = Date()
+        let range = calendar.range(of: .day, in: .month, for: now)!
+        let components = calendar.dateComponents([.year, .month], from: now)
+        let startOfMonth = calendar.date(from: components)!
+        var result: [DailyStat] = []
+        for day in range {
+            let dayDate = calendar.date(byAdding: .day, value: day - 1, to: startOfMonth)!
+            let dayEnd = calendar.date(byAdding: .day, value: 1, to: dayDate)!
+            let seconds = repository.sessions
+                .filter { $0.timestamp >= dayDate && $0.timestamp < dayEnd }
+                .reduce(0) { $0 + $1.duration }
+            result.append(DailyStat(date: dayDate, minutes: Double(seconds) / 60.0))
+        }
+        return result
+    }
+
+    func yearMonthlyData() -> [MonthlyStat] {
+        let calendar = Calendar.current
+        let year = calendar.component(.year, from: Date())
+        var result: [MonthlyStat] = []
+        for month in 1...12 {
+            let components = DateComponents(year: year, month: month)
+            guard let startOfMonth = calendar.date(from: components),
+                  let endOfMonth = calendar.date(byAdding: .month, value: 1, to: startOfMonth) else { continue }
+            let monthSessions = repository.sessions.filter {
+                $0.timestamp >= startOfMonth && $0.timestamp < endOfMonth
+            }
+            let totalSeconds = monthSessions.reduce(0) { $0 + $1.duration }
+            result.append(MonthlyStat(
+                month: month,
+                count: monthSessions.count,
+                minutes: Double(totalSeconds) / 60.0
+            ))
+        }
+        return result
+    }
+
+    func latestStatusMessage(daysAgo: Int) -> (status: String, motivation: String) {
+        switch daysAgo {
+        case 0:
+            return ("今天", "今天已经努力过了！")
+        case 1:
+            return ("昨天", "昨天休息了一天，今天继续加油！")
+        case 2...3:
+            return ("\(daysAgo)天前", "已经\(daysAgo)天没有记录了，要注意节制哦！")
+        case 4...7:
+            return ("\(daysAgo)天前", "\(daysAgo)天了！你是不是在养精蓄锐？")
+        default:
+            return ("\(daysAgo)天前", "\(daysAgo)天了！不要忘记记录哦～")
+        }
+    }
+
+    func formatDateTime(_ date: Date) -> String {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return f.string(from: date)
+    }
+
+    func formatDuration(_ seconds: Int) -> String {
+        let h = seconds / 3600
+        let m = (seconds % 3600) / 60
+        let s = seconds % 60
+        if h > 0 { return "\(h)小时\(m)分\(s)秒" }
+        if m > 0 { return "\(m)分\(s)秒" }
+        return "\(s)秒"
+    }
+}
+
+struct StatRow: View {
+    let label: String
+    let value: String
+
+    var body: some View {
+        HStack {
+            Text(label).foregroundStyle(.secondary)
+            Spacer()
+            Text(value).bold()
+        }
+        .font(.subheadline)
+    }
+}


### PR DESCRIPTION
## Summary
- Add a SwiftUI iOS project alongside the existing app
- Add session models, timer/update/reminder services, and SwiftUI views
- Wire the app entry into the new tab-based interface

## Testing
- Not run; Xcode build/test was not requested